### PR TITLE
Some OpenBSD Fixes

### DIFF
--- a/make/common/JdkNativeCompilation.gmk
+++ b/make/common/JdkNativeCompilation.gmk
@@ -195,6 +195,7 @@ define AddJdkLibrary
   endif
   ifeq ($(call isTargetOsEnv, bsd.openbsd)+$$($1_$2_MODULE):$$($1_$2_NAME), true+java.base:jli)
     $1_$2_STATIC_LIBRARY := true
+    $1_LIBS += $(LIBZ_LIBS) $(LIBPTHREAD)
   endif
   ifeq ($$($1_$2_MODULE):$$($1_$2_NAME), gtest:gtest)
     $1_$2_STATIC_LIBRARY := true

--- a/make/common/modules/LauncherCommon.gmk
+++ b/make/common/modules/LauncherCommon.gmk
@@ -93,10 +93,6 @@ define SetupBuildLauncherBody
     endif
   endif
 
-  ifeq ($(call isTargetOs, bsd), true)
-    $1_LIBS += $(LIBZ_LIBS) $(LIBPTHREAD)
-  endif
-
   ifneq ($$($1_JAVA_ARGS), )
     $1_JAVA_ARGS_STR := '{ $$(strip $$(foreach a, \
         $$(addprefix -J, $$($1_JAVA_ARGS)) $$($1_LAUNCHER_CLASS), "$$a"$(COMMA) )) }'


### PR DESCRIPTION
Hi Greg,

I believe when I added zlib and pthread for *BSD, it should have been just for when libjli is built statically like on OpenBSD. I also added OpenBSD/NetBSD support to the new KERN_PROC sysctl(2) call in VirtualMachineImpl.c. When you get a chance, could you try this branch on FreeBSD to confirm the zlib/pthread change is correct there?

Thanks,
-Kurt 