### PR TITLE
Limit the name passed to pthread_set_name_np(3) to MAXCOMLEN

### DIFF
--- a/src/hotspot/os/bsd/os_bsd.cpp
+++ b/src/hotspot/os/bsd/os_bsd.cpp
@@ -2381,7 +2381,9 @@ void os::set_native_thread_name(const char *name) {
     (void) os::snprintf(buf, sizeof(buf), "Java: %s", name);
     pthread_setname_np(buf);
 #elif defined(__FreeBSD__) || defined(__OpenBSD__)
-    pthread_set_name_np(pthread_self(), name);
+    char buf[MAXCOMLEN+1];
+    (void) os::snprintf(buf, sizeof(buf), "%s", name);
+    pthread_set_name_np(pthread_self(), buf);
 #elif defined(__NetBSD__)
     pthread_setname_np(pthread_self(), "%s", const_cast<char *>(name));
 #endif


### PR DESCRIPTION
so that at least the initial part of the name is set for the thread.

I noticed on OpenBSD in top with threads displayed that some threads that should have their name set did not. Turns out there's a max thread name size of `MAXCOMLEN` on OpenBSD so larger thread names were failing the `pthread_set_name_np() `call. Looking at FreeBSD's [code](https://github.com/freebsd/freebsd-src/blob/main/sys/kern/kern_thr.c#L607) it appears FreeBSD has the same limit.