### PR TITLE
Restore -z,defs for *BSD in LDFLAGS

### DIFF
--- a/make/autoconf/flags-ldflags.m4
+++ b/make/autoconf/flags-ldflags.m4
@@ -46,15 +46,11 @@ AC_DEFUN([FLAGS_SETUP_LDFLAGS_HELPER],
 [
   # Setup basic LDFLAGS
   if test "x$TOOLCHAIN_TYPE" = xgcc; then
-    # Add -z defs, to forbid undefined symbols in object files.
-    if test "x$OPENJDK_TARGET_OS" != xbsd; then
-        BASIC_LDFLAGS="-Wl,-z,defs"
-    fi
-
-    # add relro (mark relocations read only) for all libs
+    # Add -z,defs, to forbid undefined symbols in object files.
+    # add -z,relro (mark relocations read only) for all libs
     # add -z,now ("full relro" - more of the Global Offset Table GOT is marked read only)
     # add --no-as-needed to disable default --as-needed link flag on some GCC toolchains
-    BASIC_LDFLAGS="$BASIC_LDFLAGS -Wl,-z,relro -Wl,-z,now -Wl,--no-as-needed -Wl,--exclude-libs,ALL"
+    BASIC_LDFLAGS="-Wl,-z,defs -Wl,-z,relro -Wl,-z,now -Wl,--no-as-needed -Wl,--exclude-libs,ALL"
     # Linux : remove unused code+data in link step
     if test "x$ENABLE_LINKTIME_GC" = xtrue; then
       if test "x$OPENJDK_TARGET_CPU" = xs390x; then


### PR DESCRIPTION
Allowing undefined symbols does not appear to be needed for BSD and reverting this change brings flags-ldflags.m4 closer to master branch. The tier1 tests pass the same on both OpenBSD and FreeBSD. @snake66 do you recall why you made this change?