### PR TITLE
Fix sa agent on FreeBSD part 1

### DIFF
--- a/src/jdk.hotspot.agent/bsd/native/libsaproc/BsdDebuggerLocal.cpp
+++ b/src/jdk.hotspot.agent/bsd/native/libsaproc/BsdDebuggerLocal.cpp
@@ -103,7 +103,6 @@ struct ps_prochandle* get_proc_handle(JNIEnv* env, jobject this_obj) {
 extern "C"
 JNIEXPORT void JNICALL Java_sun_jvm_hotspot_debugger_bsd_BsdDebuggerLocal_init0
   (JNIEnv *env, jclass cls) {
-  jclass listClass;
 
   if (init_libproc(getenv("LIBSAPROC_DEBUG") != NULL) != true) {
      THROW_NEW_DEBUGGER_EXCEPTION("can't initialize libproc");
@@ -127,8 +126,9 @@ JNIEXPORT void JNICALL Java_sun_jvm_hotspot_debugger_bsd_BsdDebuggerLocal_init0
   getThreadForThreadId_ID = env->GetMethodID(cls, "getThreadForThreadId",
                                                      "(J)Lsun/jvm/hotspot/debugger/ThreadProxy;");
   CHECK_EXCEPTION;
+
   // java.util.List method we call
-  listClass = env->FindClass("java/util/List");
+  jclass listClass = env->FindClass("java/util/List");
   CHECK_EXCEPTION;
   listAdd_ID = env->GetMethodID(listClass, "add", "(Ljava/lang/Object;)Z");
   CHECK_EXCEPTION;

--- a/src/jdk.hotspot.agent/bsd/native/libsaproc/BsdDebuggerLocal.cpp
+++ b/src/jdk.hotspot.agent/bsd/native/libsaproc/BsdDebuggerLocal.cpp
@@ -35,20 +35,8 @@
 #define amd64 1
 #endif
 
-#if defined(i386) && !defined(i586)
-#define i586 1
-#endif
-
-#ifdef i586
-#include "sun_jvm_hotspot_debugger_x86_X86ThreadContext.h"
-#endif
-
 #ifdef amd64
 #include "sun_jvm_hotspot_debugger_amd64_AMD64ThreadContext.h"
-#endif
-
-#if defined(sparc) || defined(sparcv9)
-#include "sun_jvm_hotspot_debugger_sparc_SPARCThreadContext.h"
 #endif
 
 #if defined(ppc64) || defined(ppc64le)

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/bsd/BsdDebuggerLocal.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/bsd/BsdDebuggerLocal.java
@@ -296,6 +296,7 @@ public class BsdDebuggerLocal extends DebuggerBase implements BsdDebugger {
     public synchronized void attach(String execName, String coreName) {
         checkAttached();
         loadObjectList = new ArrayList<>();
+        threadList = new ArrayList<>();
         attach0(execName, coreName);
         attached = true;
         isCore = true;

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/bsd/BsdDebuggerLocal.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/bsd/BsdDebuggerLocal.java
@@ -80,7 +80,11 @@ public class BsdDebuggerLocal extends DebuggerBase implements BsdDebugger {
     // loadObjectList is filled by attach0 method
     private List<LoadObject> loadObjectList;
 
+    // MacOS code uses this thread list
     private List<JavaThread> javaThreadList;
+
+    // BSD code uses this thread list
+    private List<ThreadProxy> threadList;
 
     // called by native method lookupByAddress0
     private ClosestSymbol createClosestSymbol(String name, long offset) {
@@ -272,6 +276,7 @@ public class BsdDebuggerLocal extends DebuggerBase implements BsdDebugger {
     public synchronized void attach(int processID) throws DebuggerException {
         checkAttached();
         loadObjectList = new ArrayList<>();
+        threadList = new ArrayList<>();
         class AttachTask implements WorkerThreadTask {
            int pid;
            public void doit(BsdDebuggerLocal debugger) {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/bsd/BsdDebuggerLocal.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/bsd/BsdDebuggerLocal.java
@@ -309,6 +309,7 @@ public class BsdDebuggerLocal extends DebuggerBase implements BsdDebugger {
             return false;
         }
 
+        threadList = null;
         javaThreadList = null;
         loadObjectList = null;
 


### PR DESCRIPTION
Add back the `threadList` member that was removed by the upstream changes to the macOS port. Also clean up some defines for obsolete architectures.

This fixes _most_ of the serviceability tests, but there's still about 10 test failures remaining. Thought it was worthwhile to submit as is now in any case, while I continue to work on the remaining issues.

While the current fix is pretty simple it was not all that easy to find what was the cause of the problem. Since the debug functions are running in a worker thread the otherwise apparent error of trying to access a member that was not initialized from JNI code was never brought up into any logs or output. I suspect it is due to a deadlock between the two member function both synctonizing on the same lock from both the worker thread and the main thread when this happens.