### PR TITLE
Fix os::Bsd::get_process_uid() for OpenBSD and NetBSD

### DIFF
--- a/src/hotspot/os/bsd/os_bsd.cpp
+++ b/src/hotspot/os/bsd/os_bsd.cpp
@@ -127,19 +127,30 @@
   #define OS_X_10_9_0_KERNEL_MAJOR_VERSION 13
 #endif
 
-#if defined(__OpenBSD__)
+#if defined(__APPLE__)
+#define KERN_PROC_MIB  KERN_PROC
+#define KINFO_PROC_T   kinfo_proc
+#define KI_UID         kp_eproc.e_ucred.cr_uid
+#define KI_PID         kp_proc.p_pid
+#elif defined(__OpenBSD__)
 #define KERN_PROC_MIB  KERN_PROC
 #define KINFO_PROC_T   kinfo_proc
 #define KI_RSS         p_vm_rssize
+#define KI_UID         p_uid
+#define KI_PID         p_pid
 #elif defined(__FreeBSD__)
 #include <sys/user.h>
 #define KERN_PROC_MIB  KERN_PROC
 #define KINFO_PROC_T   kinfo_proc
 #define KI_RSS         ki_rssize
+#define KI_UID         ki_uid
+#define KI_PID         ki_pid
 #elif defined(__NetBSD__)
 #define KERN_PROC_MIB  KERN_PROC2
 #define KINFO_PROC_T   kinfo_proc2
 #define KI_RSS         p_vm_rssize
+#define KI_UID         p_uid
+#define KI_PID         p_pid
 #endif
 
 #ifndef MAP_ANONYMOUS
@@ -1024,23 +1035,20 @@ pid_t os::Bsd::gettid() {
 
 // Returns the uid of a process or -1 on error.
 uid_t os::Bsd::get_process_uid(pid_t pid) {
-  struct kinfo_proc kp;
+  struct KINFO_PROC_T kp;
   size_t size = sizeof kp;
-  int mib_kern[4] = {CTL_KERN, KERN_PROC, KERN_PROC_PID, pid};
-  if (sysctl(mib_kern, 4, &kp, &size, nullptr, 0) == 0) {
-#if defined(__FreeBSD__)
-    if (size > 0 && kp.ki_pid == pid) {
-      return kp.ki_uid;
-    }
-#elif defined(__OpenBSD__)
-    if (size > 0 && kp.p_pid == pid) {
-      return kp.p_uid;
-    }
+#if defined(__FreeBSD__) || defined(__APPLE__)
+  u_int namelen = 4;
+  int mib_kern[4] = {CTL_KERN, KERN_PROC_MIB, KERN_PROC_PID, pid};
 #else
-    if (size > 0 && kp.kp_proc.p_pid == pid) {
-      return kp.kp_eproc.e_ucred.cr_uid;
-    }
+  u_int namelen = 6;
+  int mib_kern[6] = {CTL_KERN, KERN_PROC_MIB, KERN_PROC_PID, pid,
+                static_cast<int>(size), 1};
 #endif
+  if (sysctl(mib_kern, namelen, &kp, &size, nullptr, 0) == 0) {
+    if (size > 0 && kp.KI_PID == pid) {
+      return kp.KI_UID;
+    }
   }
   return (uid_t)-1;
 }


### PR DESCRIPTION
Adjust implementation to work for *BSD and Apple