### PR TITLE
Fix sa agent on freebsd

### DIFF
--- a/src/jdk.hotspot.agent/bsd/native/libsaproc/BsdDebuggerLocal.cpp
+++ b/src/jdk.hotspot.agent/bsd/native/libsaproc/BsdDebuggerLocal.cpp
@@ -338,14 +338,8 @@ JNIEXPORT jlongArray JNICALL Java_sun_jvm_hotspot_debugger_bsd_BsdDebuggerLocal_
   }
 
 #undef NPRGREG
-#ifdef i586
-#define NPRGREG sun_jvm_hotspot_debugger_x86_X86ThreadContext_NPRGREG
-#endif
 #ifdef amd64
 #define NPRGREG sun_jvm_hotspot_debugger_amd64_AMD64ThreadContext_NPRGREG
-#endif
-#if defined(sparc) || defined(sparcv9)
-#define NPRGREG sun_jvm_hotspot_debugger_sparc_SPARCThreadContext_NPRGREG
 #endif
 #if defined(ppc64) || defined(ppc64le)
 #define NPRGREG sun_jvm_hotspot_debugger_ppc64_PPC64ThreadContext_NPRGREG
@@ -359,27 +353,6 @@ JNIEXPORT jlongArray JNICALL Java_sun_jvm_hotspot_debugger_bsd_BsdDebuggerLocal_
   regs = env->GetLongArrayElements(array, &isCopy);
 
 #undef REG_INDEX
-
-#ifdef i586
-#define REG_INDEX(reg) sun_jvm_hotspot_debugger_x86_X86ThreadContext_##reg
-
-  regs[REG_INDEX(GS)]  = (uintptr_t) gregs.r_gs;
-  regs[REG_INDEX(FS)]  = (uintptr_t) gregs.r_fs;
-  regs[REG_INDEX(ES)]  = (uintptr_t) gregs.r_es;
-  regs[REG_INDEX(DS)]  = (uintptr_t) gregs.r_ds;
-  regs[REG_INDEX(EDI)] = (uintptr_t) gregs.r_edi;
-  regs[REG_INDEX(ESI)] = (uintptr_t) gregs.r_esi;
-  regs[REG_INDEX(FP)] = (uintptr_t) gregs.r_ebp;
-  regs[REG_INDEX(SP)] = (uintptr_t) gregs.r_isp;
-  regs[REG_INDEX(EBX)] = (uintptr_t) gregs.r_ebx;
-  regs[REG_INDEX(EDX)] = (uintptr_t) gregs.r_edx;
-  regs[REG_INDEX(ECX)] = (uintptr_t) gregs.r_ecx;
-  regs[REG_INDEX(EAX)] = (uintptr_t) gregs.r_eax;
-  regs[REG_INDEX(PC)] = (uintptr_t) gregs.r_eip;
-  regs[REG_INDEX(CS)]  = (uintptr_t) gregs.r_cs;
-  regs[REG_INDEX(SS)]  = (uintptr_t) gregs.r_ss;
-
-#endif /* i586 */
 
 #ifdef amd64
 #define REG_INDEX(reg) sun_jvm_hotspot_debugger_amd64_AMD64ThreadContext_##reg
@@ -418,38 +391,6 @@ JNIEXPORT jlongArray JNICALL Java_sun_jvm_hotspot_debugger_bsd_BsdDebuggerLocal_
 
 #endif /* amd64 */
 
-#if defined(sparc) || defined(sparcv9)
-
-#define REG_INDEX(reg) sun_jvm_hotspot_debugger_sparc_SPARCThreadContext_##reg
-
-#ifdef _LP64
-  regs[REG_INDEX(R_PSR)] = gregs.tstate;
-  regs[REG_INDEX(R_PC)]  = gregs.tpc;
-  regs[REG_INDEX(R_nPC)] = gregs.tnpc;
-  regs[REG_INDEX(R_Y)]   = gregs.y;
-#else
-  regs[REG_INDEX(R_PSR)] = gregs.psr;
-  regs[REG_INDEX(R_PC)]  = gregs.pc;
-  regs[REG_INDEX(R_nPC)] = gregs.npc;
-  regs[REG_INDEX(R_Y)]   = gregs.y;
-#endif
-  regs[REG_INDEX(R_G0)]  =            0 ;
-  regs[REG_INDEX(R_G1)]  = gregs.u_regs[0];
-  regs[REG_INDEX(R_G2)]  = gregs.u_regs[1];
-  regs[REG_INDEX(R_G3)]  = gregs.u_regs[2];
-  regs[REG_INDEX(R_G4)]  = gregs.u_regs[3];
-  regs[REG_INDEX(R_G5)]  = gregs.u_regs[4];
-  regs[REG_INDEX(R_G6)]  = gregs.u_regs[5];
-  regs[REG_INDEX(R_G7)]  = gregs.u_regs[6];
-  regs[REG_INDEX(R_O0)]  = gregs.u_regs[7];
-  regs[REG_INDEX(R_O1)]  = gregs.u_regs[8];
-  regs[REG_INDEX(R_O2)]  = gregs.u_regs[ 9];
-  regs[REG_INDEX(R_O3)]  = gregs.u_regs[10];
-  regs[REG_INDEX(R_O4)]  = gregs.u_regs[11];
-  regs[REG_INDEX(R_O5)]  = gregs.u_regs[12];
-  regs[REG_INDEX(R_O6)]  = gregs.u_regs[13];
-  regs[REG_INDEX(R_O7)]  = gregs.u_regs[14];
-#endif /* sparc */
 #if defined(ppc64) || defined(ppc64le)
 #define REG_INDEX(reg) sun_jvm_hotspot_debugger_ppc64_PPC64ThreadContext_##reg
 

--- a/src/jdk.hotspot.agent/bsd/native/libsaproc/BsdDebuggerLocal.cpp
+++ b/src/jdk.hotspot.agent/bsd/native/libsaproc/BsdDebuggerLocal.cpp
@@ -178,8 +178,8 @@ bool fill_java_threads(JNIEnv* env, jobject this_obj, struct ps_prochandle* ph) 
         break;
       }
 #elif defined(aarch64)
-      if ((regs.r_sp < end && regs.r_sp >= beg) ||
-          (regs.r_fp < end && regs.r_fp >= beg)) {
+      if ((regs.sp < end && regs.sp >= beg) ||
+          (regs.x[29] < end && regs.x[29] >= beg)) {
         set_lwp_id(ph, i, uid);
         break;
       }

--- a/src/jdk.hotspot.agent/bsd/native/libsaproc/BsdDebuggerLocal.cpp
+++ b/src/jdk.hotspot.agent/bsd/native/libsaproc/BsdDebuggerLocal.cpp
@@ -183,6 +183,11 @@ bool fill_java_threads(JNIEnv* env, jobject this_obj, struct ps_prochandle* ph) 
         set_lwp_id(ph, i, uid);
         break;
       }
+#elif defined(ppc64) || defined(ppc64le)
+      if (regs.fixreg[1] < end && regs.fixreg[1] >= beg) {
+        set_lwp_id(ph, i, uid);
+        break;
+      }
 #else
 #error UNSUPPORTED_ARCH
 #endif

--- a/src/jdk.hotspot.agent/bsd/native/libsaproc/BsdDebuggerLocal.cpp
+++ b/src/jdk.hotspot.agent/bsd/native/libsaproc/BsdDebuggerLocal.cpp
@@ -30,6 +30,7 @@
 #include <cxxabi.h>
 #include <jni.h>
 #include "libproc.h"
+#include "libproc_impl.h"
 
 #if defined(x86_64) && !defined(amd64)
 #define amd64 1
@@ -70,13 +71,16 @@ public:
 };
 
 static jfieldID p_ps_prochandle_ID = 0;
-static jfieldID threadList_ID = 0;
 static jfieldID loadObjectList_ID = 0;
 
 static jmethodID createClosestSymbol_ID = 0;
 static jmethodID createLoadObject_ID = 0;
 static jmethodID getThreadForThreadId_ID = 0;
 static jmethodID listAdd_ID = 0;
+static jmethodID getJavaThreadsInfo_ID = 0;
+
+// indicator if thread id (lwpid_t) was set
+static bool _threads_filled = false;
 
 #define CHECK_EXCEPTION_(value) if (env->ExceptionCheck()) { return value; }
 #define CHECK_EXCEPTION if (env->ExceptionCheck()) { return;}
@@ -111,8 +115,6 @@ JNIEXPORT void JNICALL Java_sun_jvm_hotspot_debugger_bsd_BsdDebuggerLocal_init0
   // fields we use
   p_ps_prochandle_ID = env->GetFieldID(cls, "p_ps_prochandle", "J");
   CHECK_EXCEPTION;
-  threadList_ID = env->GetFieldID(cls, "threadList", "Ljava/util/List;");
-  CHECK_EXCEPTION;
   loadObjectList_ID = env->GetFieldID(cls, "loadObjectList", "Ljava/util/List;");
   CHECK_EXCEPTION;
 
@@ -125,6 +127,8 @@ JNIEXPORT void JNICALL Java_sun_jvm_hotspot_debugger_bsd_BsdDebuggerLocal_init0
   CHECK_EXCEPTION;
   getThreadForThreadId_ID = env->GetMethodID(cls, "getThreadForThreadId",
                                                      "(J)Lsun/jvm/hotspot/debugger/ThreadProxy;");
+  CHECK_EXCEPTION;
+  getJavaThreadsInfo_ID = env->GetMethodID(cls, "getJavaThreadsInfo", "()[J");
   CHECK_EXCEPTION;
 
   // java.util.List method we call
@@ -146,52 +150,74 @@ JNIEXPORT jint JNICALL Java_sun_jvm_hotspot_debugger_bsd_BsdDebuggerLocal_getAdd
 
 }
 
+/** Only used for core file reading, for compatibility with the MacOS Java code.
+  */
+bool fill_java_threads(JNIEnv* env, jobject this_obj, struct ps_prochandle* ph) {
+  struct reg regs;
 
-static void fillThreadsAndLoadObjects(JNIEnv* env, jobject this_obj, struct ps_prochandle* ph) {
-  int n = 0, i = 0;
+  jlongArray thrinfos = (jlongArray)env->CallObjectMethod(this_obj, getJavaThreadsInfo_ID);
+  CHECK_EXCEPTION_(false);
+  int len = (int)env->GetArrayLength(thrinfos);
+  uint64_t* cinfos = (uint64_t *)env->GetLongArrayElements(thrinfos, NULL);
+  CHECK_EXCEPTION_(false);
+  int n = get_num_threads(ph);
+  for (int i = 0; i < n; i++) {
+    if (!get_nth_lwp_regs(ph, i, &regs)) {
+      //print_debug("Could not get regs of thread %d, already set!\n", i);
+      env->ReleaseLongArrayElements(thrinfos, (jlong*)cinfos, 0);
+      return false;
+    }
+    for (int j = 0; j < len; j += 3) {
+      lwpid_t  uid = cinfos[j];
+      uint64_t beg = cinfos[j + 1];
+      uint64_t end = cinfos[j + 2];
+#if defined(amd64)
+      if ((regs.r_rsp < end && regs.r_rsp >= beg) ||
+          (regs.r_rbp < end && regs.r_rbp >= beg)) {
+        set_lwp_id(ph, i, uid);
+        break;
+      }
+#elif defined(aarch64)
+      if ((regs.r_sp < end && regs.r_sp >= beg) ||
+          (regs.r_fp < end && regs.r_fp >= beg)) {
+        set_lwp_id(ph, i, uid);
+        break;
+      }
+#else
+#error UNSUPPORTED_ARCH
+#endif
+    }
+  }
+  env->ReleaseLongArrayElements(thrinfos, (jlong*)cinfos, 0);
+  CHECK_EXCEPTION_(false);
+  return true;
+}
 
-  // add threads
-  n = get_num_threads(ph);
-  for (i = 0; i < n; i++) {
-    jobject thread;
-    jobject threadList;
-    lwpid_t lwpid;
+static void fillLoadObjects(JNIEnv* env, jobject this_obj, struct ps_prochandle* ph) {
+  int n = get_num_libs(ph);
 
-    lwpid = get_lwp_id(ph, i);
-    thread = env->CallObjectMethod(this_obj, getThreadForThreadId_ID, (jlong)lwpid);
+  jobject loadObjectList = env->GetObjectField(this_obj, loadObjectList_ID);
+  CHECK_EXCEPTION;
+
+  for (int i = 0; i < n; i++) {
+    uintptr_t base, memsz;
+    const char* name;
+    jstring str;
+
+    get_lib_addr_range(ph, i, &base, &memsz);
+    name = get_lib_name(ph, i);
+
+    str = env->NewStringUTF(name);
     CHECK_EXCEPTION;
-    threadList = env->GetObjectField(this_obj, threadList_ID);
+    jobject loadObject = env->CallObjectMethod(this_obj, createLoadObject_ID, str, (jlong)memsz, (jlong)base);
     CHECK_EXCEPTION;
-    env->CallBooleanMethod(threadList, listAdd_ID, thread);
+    env->CallBooleanMethod(loadObjectList, listAdd_ID, loadObject);
     CHECK_EXCEPTION;
-    env->DeleteLocalRef(thread);
-    env->DeleteLocalRef(threadList);
+    env->DeleteLocalRef(str);
+    env->DeleteLocalRef(loadObject);
   }
 
-  // add load objects
-  n = get_num_libs(ph);
-  for (i = 0; i < n; i++) {
-     uintptr_t base, memsz;
-     const char* name;
-     jobject loadObject;
-     jobject loadObjectList;
-     jstring str;
-
-     get_lib_addr_range(ph, i, &base, &memsz);
-     name = get_lib_name(ph, i);
-
-     str = env->NewStringUTF(name);
-     CHECK_EXCEPTION;
-     loadObject = env->CallObjectMethod(this_obj, createLoadObject_ID, str, (jlong)memsz, (jlong)base);
-     CHECK_EXCEPTION;
-     loadObjectList = env->GetObjectField(this_obj, loadObjectList_ID);
-     CHECK_EXCEPTION;
-     env->CallBooleanMethod(loadObjectList, listAdd_ID, loadObject);
-     CHECK_EXCEPTION;
-     env->DeleteLocalRef(str);
-     env->DeleteLocalRef(loadObject);
-     env->DeleteLocalRef(loadObjectList);
-  }
+  env->DeleteLocalRef(loadObjectList);
 }
 
 /*
@@ -211,7 +237,7 @@ JNIEXPORT void JNICALL Java_sun_jvm_hotspot_debugger_bsd_BsdDebuggerLocal_attach
     THROW_NEW_DEBUGGER_EXCEPTION(msg);
   }
   env->SetLongField(this_obj, p_ps_prochandle_ID, (jlong)(intptr_t)ph);
-  fillThreadsAndLoadObjects(env, this_obj, ph);
+  fillLoadObjects(env, this_obj, ph);
 }
 
 /*
@@ -232,7 +258,7 @@ JNIEXPORT void JNICALL Java_sun_jvm_hotspot_debugger_bsd_BsdDebuggerLocal_attach
     THROW_NEW_DEBUGGER_EXCEPTION("Can't attach to the core file. For more information, export LIBSAPROC_DEBUG=1 and try again.");
   }
   env->SetLongField(this_obj, p_ps_prochandle_ID, (jlong)(intptr_t)ph);
-  fillThreadsAndLoadObjects(env, this_obj, ph);
+  fillLoadObjects(env, this_obj, ph);
 }
 
 /*
@@ -257,7 +283,6 @@ JNIEXPORT void JNICALL Java_sun_jvm_hotspot_debugger_bsd_BsdDebuggerLocal_detach
 extern "C"
 JNIEXPORT jlong JNICALL Java_sun_jvm_hotspot_debugger_bsd_BsdDebuggerLocal_lookupByName0
   (JNIEnv *env, jobject this_obj, jstring objectName, jstring symbolName) {
-  jlong addr;
   struct ps_prochandle* ph = get_proc_handle(env, this_obj);
   // Note, objectName is ignored, and may in fact be NULL.
   // lookup_symbol will always search all objects/libs
@@ -266,7 +291,7 @@ JNIEXPORT jlong JNICALL Java_sun_jvm_hotspot_debugger_bsd_BsdDebuggerLocal_looku
   AutoJavaString symbolName_cstr(env, symbolName);
   CHECK_EXCEPTION_(0);
 
-  addr = (jlong) lookup_symbol(ph, NULL, symbolName_cstr);
+  jlong addr = (jlong) lookup_symbol(ph, NULL, symbolName_cstr);
   return addr;
 }
 
@@ -327,6 +352,19 @@ JNIEXPORT jlongArray JNICALL Java_sun_jvm_hotspot_debugger_bsd_BsdDebuggerLocal_
   jlong *regs;
 
   struct ps_prochandle* ph = get_proc_handle(env, this_obj);
+  if (ph != NULL && ph->core != NULL) {
+    if (!_threads_filled)  {
+      fprintf(stdout, "[+] %s: Threads not filled...\n", __FUNCTION__);
+      fflush(stdout);
+      if (!fill_java_threads(env, this_obj, ph)) {
+        throw_new_debugger_exception(env, "Failed to fill in threads");
+        return 0;
+      } else {
+        _threads_filled = true;
+      }
+    }
+  }
+
   if (get_lwp_regs(ph, lwp_id, &gregs) != true) {
     // This is not considered fatal and does happen on occasion, usually with an
     // ESRCH error. The root cause is not fully understood, but by ignoring this error

--- a/src/jdk.hotspot.agent/bsd/native/libsaproc/BsdDebuggerLocal.cpp
+++ b/src/jdk.hotspot.agent/bsd/native/libsaproc/BsdDebuggerLocal.cpp
@@ -354,8 +354,6 @@ JNIEXPORT jlongArray JNICALL Java_sun_jvm_hotspot_debugger_bsd_BsdDebuggerLocal_
   struct ps_prochandle* ph = get_proc_handle(env, this_obj);
   if (ph != NULL && ph->core != NULL) {
     if (!_threads_filled)  {
-      fprintf(stdout, "[+] %s: Threads not filled...\n", __FUNCTION__);
-      fflush(stdout);
       if (!fill_java_threads(env, this_obj, ph)) {
         throw_new_debugger_exception(env, "Failed to fill in threads");
         return 0;

--- a/src/jdk.hotspot.agent/bsd/native/libsaproc/libproc_impl.c
+++ b/src/jdk.hotspot.agent/bsd/native/libsaproc/libproc_impl.c
@@ -507,7 +507,6 @@ lwpid_t get_lwp_id(struct ps_prochandle* ph, int index) {
   return 0;
 }
 
-#ifdef __APPLE__
 // set lwp_id of n'th thread
 bool set_lwp_id(struct ps_prochandle* ph, int index, lwpid_t lwpid) {
   int count = 0;
@@ -540,8 +539,6 @@ bool get_nth_lwp_regs(struct ps_prochandle* ph, int index, struct reg* regs) {
   }
   return false;
 }
-
-#endif // __APPLE__
 
 // get regs for a given lwp
 bool get_lwp_regs(struct ps_prochandle* ph, lwpid_t lwp_id, struct reg* regs) {

--- a/src/jdk.hotspot.agent/bsd/native/libsaproc/ps_proc.c
+++ b/src/jdk.hotspot.agent/bsd/native/libsaproc/ps_proc.c
@@ -49,63 +49,41 @@ typedef enum {
   ATTACH_THREAD_DEAD
 } attach_state_t;
 
-static inline uintptr_t align(uintptr_t ptr, size_t size) {
-  return (ptr & ~(size - 1));
-}
-
 // ---------------------------------------------
 // ptrace functions
 // ---------------------------------------------
 
 // read "size" bytes of data from "addr" within the target process.
-// unlike the standard ptrace() function, process_read_data() can handle
-// unaligned address - alignment check, if required, should be done
-// before calling process_read_data.
+//
+// On BSD ptrace(2) does not have any alignment requirements on the remote process' address
 
 static bool process_read_data(struct ps_prochandle* ph, uintptr_t addr, char *buf, size_t size) {
-  int rslt;
-  size_t i, words;
+
   uintptr_t end_addr = addr + size;
-  uintptr_t aligned_addr = align(addr, sizeof(int));
+  size_t words = (end_addr - addr) / sizeof(int);
 
-  if (aligned_addr != addr) {
-    char *ptr = (char *)&rslt;
+  for (size_t i = 0; i < words; i++) {
     errno = 0;
-    rslt = ptrace(PT_READ_D, ph->pid, (caddr_t) aligned_addr, 0);
+    int rslt = ptrace(PT_READ_D, ph->pid, (caddr_t) addr, 0);
     if (errno) {
-      print_error("ptrace(PT_READ_D, ..) failed for %d bytes @ %lx\n", size, addr);
-      return false;
-    }
-    for (; aligned_addr != addr; aligned_addr++, ptr++);
-    for (; ((intptr_t)aligned_addr % sizeof(int)) && aligned_addr < end_addr;
-        aligned_addr++)
-       *(buf++) = *(ptr++);
-  }
-
-  words = (end_addr - aligned_addr) / sizeof(int);
-
-  // assert((intptr_t)aligned_addr % sizeof(int) == 0);
-  for (i = 0; i < words; i++) {
-    errno = 0;
-    rslt = ptrace(PT_READ_D, ph->pid, (caddr_t) aligned_addr, 0);
-    if (errno) {
-      print_error("ptrace(PT_READ_D, ..) failed for %d bytes @ %lx\n", size, addr);
+      print_error("ptrace(PT_READ_D, ..) failed with errno = %d for %d bytes @ %lx\n", errno, size, addr);
       return false;
     }
     *(int *)buf = rslt;
     buf += sizeof(int);
-    aligned_addr += sizeof(int);
+    addr += sizeof(int);
   }
 
-  if (aligned_addr != end_addr) {
+  if (addr < end_addr) {
+    int rslt;
     char *ptr = (char *)&rslt;
     errno = 0;
-    rslt = ptrace(PT_READ_D, ph->pid, (caddr_t) aligned_addr, 0);
+    rslt = ptrace(PT_READ_D, ph->pid, (caddr_t) addr, 0);
     if (errno) {
-      print_error("ptrace(PT_READ_D, ..) failed for %d bytes @ %lx\n", size, addr);
+      print_error("ptrace(PT_READ_D, ..) failed with errno = %d for remaining %d bytes @ %lx\n", errno, end_addr - addr, addr);
       return false;
     }
-    for (; aligned_addr != end_addr; aligned_addr++)
+    for (; addr != end_addr; addr++)
        *(buf++) = *(ptr++);
   }
   return true;

--- a/src/jdk.hotspot.agent/bsd/native/libsaproc/ps_proc.c
+++ b/src/jdk.hotspot.agent/bsd/native/libsaproc/ps_proc.c
@@ -121,7 +121,7 @@ static bool process_write_data(struct ps_prochandle* ph,
 static bool process_get_lwp_regs(struct ps_prochandle* ph, lwpid_t lwpid, struct reg *user) {
   // we have already attached to all thread 'pid's, just use ptrace call
   // to get regset now. Note that we don't cache regset upfront for processes.
- if (ptrace(PT_GETREGS, ph->pid, (caddr_t) user, 0) < 0) {
+ if (ptrace(PT_GETREGS, lwpid, (caddr_t) user, 0) < 0) {
    print_error("ptrace(PTRACE_GETREGS, ...) failed for lwp %d (%d)\n", lwpid, ph->pid);
    return false;
  }

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/bsd/BsdDebuggerLocal.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/bsd/BsdDebuggerLocal.java
@@ -80,11 +80,7 @@ public class BsdDebuggerLocal extends DebuggerBase implements BsdDebugger {
     // loadObjectList is filled by attach0 method
     private List<LoadObject> loadObjectList;
 
-    // MacOS code uses this thread list
     private List<JavaThread> javaThreadList;
-
-    // BSD code uses this thread list
-    private List<ThreadProxy> threadList;
 
     // called by native method lookupByAddress0
     private ClosestSymbol createClosestSymbol(String name, long offset) {
@@ -276,7 +272,6 @@ public class BsdDebuggerLocal extends DebuggerBase implements BsdDebugger {
     public synchronized void attach(int processID) throws DebuggerException {
         checkAttached();
         loadObjectList = new ArrayList<>();
-        threadList = new ArrayList<>();
         class AttachTask implements WorkerThreadTask {
            int pid;
            public void doit(BsdDebuggerLocal debugger) {
@@ -296,7 +291,6 @@ public class BsdDebuggerLocal extends DebuggerBase implements BsdDebugger {
     public synchronized void attach(String execName, String coreName) {
         checkAttached();
         loadObjectList = new ArrayList<>();
-        threadList = new ArrayList<>();
         attach0(execName, coreName);
         attached = true;
         isCore = true;
@@ -309,7 +303,6 @@ public class BsdDebuggerLocal extends DebuggerBase implements BsdDebugger {
             return false;
         }
 
-        threadList = null;
         javaThreadList = null;
         loadObjectList = null;
 


### PR DESCRIPTION
Finally seems I got to the bottom of this...

This set of patches fixes all of the Serviceability Agent issues on FreeBSD. (Not yet tested on Aarch64, and quite certainly not working on PPC64 yet). The culprit was the call to fetch the registers for a given thread on an attached process, where the pid for the main process instead of the lwpid for the thread was passed to the `ptrace(PT_GETREGS, ...)` call.

It also aligns the code more with the upstream MacOS code, as we need to be sharing with them in any case. This includes a workaround for MacOS not storing thread ID's in coredumps that we technically don't need on FreeBSD, but it seems to not get too much in the way either.

Also dropped obsolete support for Pentium and Sparc architectures from the SA code.

As always, thanks to the FreeBSD Foundation for supporting this project!