### PR TITLE
Alternative sa fix

### DIFF
--- a/src/jdk.hotspot.agent/bsd/native/libsaproc/BsdDebuggerLocal.cpp
+++ b/src/jdk.hotspot.agent/bsd/native/libsaproc/BsdDebuggerLocal.cpp
@@ -338,14 +338,8 @@ JNIEXPORT jlongArray JNICALL Java_sun_jvm_hotspot_debugger_bsd_BsdDebuggerLocal_
   }
 
 #undef NPRGREG
-#ifdef i586
-#define NPRGREG sun_jvm_hotspot_debugger_x86_X86ThreadContext_NPRGREG
-#endif
 #ifdef amd64
 #define NPRGREG sun_jvm_hotspot_debugger_amd64_AMD64ThreadContext_NPRGREG
-#endif
-#if defined(sparc) || defined(sparcv9)
-#define NPRGREG sun_jvm_hotspot_debugger_sparc_SPARCThreadContext_NPRGREG
 #endif
 #if defined(ppc64) || defined(ppc64le)
 #define NPRGREG sun_jvm_hotspot_debugger_ppc64_PPC64ThreadContext_NPRGREG
@@ -359,27 +353,6 @@ JNIEXPORT jlongArray JNICALL Java_sun_jvm_hotspot_debugger_bsd_BsdDebuggerLocal_
   regs = env->GetLongArrayElements(array, &isCopy);
 
 #undef REG_INDEX
-
-#ifdef i586
-#define REG_INDEX(reg) sun_jvm_hotspot_debugger_x86_X86ThreadContext_##reg
-
-  regs[REG_INDEX(GS)]  = (uintptr_t) gregs.r_gs;
-  regs[REG_INDEX(FS)]  = (uintptr_t) gregs.r_fs;
-  regs[REG_INDEX(ES)]  = (uintptr_t) gregs.r_es;
-  regs[REG_INDEX(DS)]  = (uintptr_t) gregs.r_ds;
-  regs[REG_INDEX(EDI)] = (uintptr_t) gregs.r_edi;
-  regs[REG_INDEX(ESI)] = (uintptr_t) gregs.r_esi;
-  regs[REG_INDEX(FP)] = (uintptr_t) gregs.r_ebp;
-  regs[REG_INDEX(SP)] = (uintptr_t) gregs.r_isp;
-  regs[REG_INDEX(EBX)] = (uintptr_t) gregs.r_ebx;
-  regs[REG_INDEX(EDX)] = (uintptr_t) gregs.r_edx;
-  regs[REG_INDEX(ECX)] = (uintptr_t) gregs.r_ecx;
-  regs[REG_INDEX(EAX)] = (uintptr_t) gregs.r_eax;
-  regs[REG_INDEX(PC)] = (uintptr_t) gregs.r_eip;
-  regs[REG_INDEX(CS)]  = (uintptr_t) gregs.r_cs;
-  regs[REG_INDEX(SS)]  = (uintptr_t) gregs.r_ss;
-
-#endif /* i586 */
 
 #ifdef amd64
 #define REG_INDEX(reg) sun_jvm_hotspot_debugger_amd64_AMD64ThreadContext_##reg
@@ -418,38 +391,6 @@ JNIEXPORT jlongArray JNICALL Java_sun_jvm_hotspot_debugger_bsd_BsdDebuggerLocal_
 
 #endif /* amd64 */
 
-#if defined(sparc) || defined(sparcv9)
-
-#define REG_INDEX(reg) sun_jvm_hotspot_debugger_sparc_SPARCThreadContext_##reg
-
-#ifdef _LP64
-  regs[REG_INDEX(R_PSR)] = gregs.tstate;
-  regs[REG_INDEX(R_PC)]  = gregs.tpc;
-  regs[REG_INDEX(R_nPC)] = gregs.tnpc;
-  regs[REG_INDEX(R_Y)]   = gregs.y;
-#else
-  regs[REG_INDEX(R_PSR)] = gregs.psr;
-  regs[REG_INDEX(R_PC)]  = gregs.pc;
-  regs[REG_INDEX(R_nPC)] = gregs.npc;
-  regs[REG_INDEX(R_Y)]   = gregs.y;
-#endif
-  regs[REG_INDEX(R_G0)]  =            0 ;
-  regs[REG_INDEX(R_G1)]  = gregs.u_regs[0];
-  regs[REG_INDEX(R_G2)]  = gregs.u_regs[1];
-  regs[REG_INDEX(R_G3)]  = gregs.u_regs[2];
-  regs[REG_INDEX(R_G4)]  = gregs.u_regs[3];
-  regs[REG_INDEX(R_G5)]  = gregs.u_regs[4];
-  regs[REG_INDEX(R_G6)]  = gregs.u_regs[5];
-  regs[REG_INDEX(R_G7)]  = gregs.u_regs[6];
-  regs[REG_INDEX(R_O0)]  = gregs.u_regs[7];
-  regs[REG_INDEX(R_O1)]  = gregs.u_regs[8];
-  regs[REG_INDEX(R_O2)]  = gregs.u_regs[ 9];
-  regs[REG_INDEX(R_O3)]  = gregs.u_regs[10];
-  regs[REG_INDEX(R_O4)]  = gregs.u_regs[11];
-  regs[REG_INDEX(R_O5)]  = gregs.u_regs[12];
-  regs[REG_INDEX(R_O6)]  = gregs.u_regs[13];
-  regs[REG_INDEX(R_O7)]  = gregs.u_regs[14];
-#endif /* sparc */
 #if defined(ppc64) || defined(ppc64le)
 #define REG_INDEX(reg) sun_jvm_hotspot_debugger_ppc64_PPC64ThreadContext_##reg
 

--- a/src/jdk.hotspot.agent/bsd/native/libsaproc/ps_proc.c
+++ b/src/jdk.hotspot.agent/bsd/native/libsaproc/ps_proc.c
@@ -49,63 +49,41 @@ typedef enum {
   ATTACH_THREAD_DEAD
 } attach_state_t;
 
-static inline uintptr_t align(uintptr_t ptr, size_t size) {
-  return (ptr & ~(size - 1));
-}
-
 // ---------------------------------------------
 // ptrace functions
 // ---------------------------------------------
 
 // read "size" bytes of data from "addr" within the target process.
-// unlike the standard ptrace() function, process_read_data() can handle
-// unaligned address - alignment check, if required, should be done
-// before calling process_read_data.
+//
+// On BSD ptrace(2) does not have any alignment requirements on the remote process' address
 
 static bool process_read_data(struct ps_prochandle* ph, uintptr_t addr, char *buf, size_t size) {
-  int rslt;
-  size_t i, words;
+
   uintptr_t end_addr = addr + size;
-  uintptr_t aligned_addr = align(addr, sizeof(int));
+  size_t words = (end_addr - addr) / sizeof(int);
 
-  if (aligned_addr != addr) {
-    char *ptr = (char *)&rslt;
+  for (size_t i = 0; i < words; i++) {
     errno = 0;
-    rslt = ptrace(PT_READ_D, ph->pid, (caddr_t) aligned_addr, 0);
+    int rslt = ptrace(PT_READ_D, ph->pid, (caddr_t) addr, 0);
     if (errno) {
-      print_error("ptrace(PT_READ_D, ..) failed for %d bytes @ %lx\n", size, addr);
-      return false;
-    }
-    for (; aligned_addr != addr; aligned_addr++, ptr++);
-    for (; ((intptr_t)aligned_addr % sizeof(int)) && aligned_addr < end_addr;
-        aligned_addr++)
-       *(buf++) = *(ptr++);
-  }
-
-  words = (end_addr - aligned_addr) / sizeof(int);
-
-  // assert((intptr_t)aligned_addr % sizeof(int) == 0);
-  for (i = 0; i < words; i++) {
-    errno = 0;
-    rslt = ptrace(PT_READ_D, ph->pid, (caddr_t) aligned_addr, 0);
-    if (errno) {
-      print_error("ptrace(PT_READ_D, ..) failed for %d bytes @ %lx\n", size, addr);
+      print_error("ptrace(PT_READ_D, ..) failed with errno = %d for %d bytes @ %lx\n", errno, size, addr);
       return false;
     }
     *(int *)buf = rslt;
     buf += sizeof(int);
-    aligned_addr += sizeof(int);
+    addr += sizeof(int);
   }
 
-  if (aligned_addr != end_addr) {
+  if (addr < end_addr) {
+    int rslt;
     char *ptr = (char *)&rslt;
     errno = 0;
-    rslt = ptrace(PT_READ_D, ph->pid, (caddr_t) aligned_addr, 0);
+    rslt = ptrace(PT_READ_D, ph->pid, (caddr_t) addr, 0);
     if (errno) {
-      print_error("ptrace(PT_READ_D, ..) failed for %d bytes @ %lx\n", size, addr);
+      print_error("ptrace(PT_READ_D, ..) failed with errno = %d for remaining %d bytes @ %lx\n", errno, end_addr - addr, addr);
       return false;
     }
-    for (; aligned_addr != end_addr; aligned_addr++)
+    for (; addr != end_addr; addr++)
        *(buf++) = *(ptr++);
   }
   return true;

--- a/src/jdk.hotspot.agent/bsd/native/libsaproc/ps_proc.c
+++ b/src/jdk.hotspot.agent/bsd/native/libsaproc/ps_proc.c
@@ -121,7 +121,7 @@ static bool process_write_data(struct ps_prochandle* ph,
 static bool process_get_lwp_regs(struct ps_prochandle* ph, lwpid_t lwpid, struct reg *user) {
   // we have already attached to all thread 'pid's, just use ptrace call
   // to get regset now. Note that we don't cache regset upfront for processes.
- if (ptrace(PT_GETREGS, ph->pid, (caddr_t) user, 0) < 0) {
+ if (ptrace(PT_GETREGS, lwpid, (caddr_t) user, 0) < 0) {
    print_error("ptrace(PTRACE_GETREGS, ...) failed for lwp %d (%d)\n", lwpid, ph->pid);
    return false;
  }

--- a/src/jdk.hotspot.agent/bsd/native/libsaproc/ps_proc.c
+++ b/src/jdk.hotspot.agent/bsd/native/libsaproc/ps_proc.c
@@ -59,33 +59,28 @@ typedef enum {
 
 static bool process_read_data(struct ps_prochandle* ph, uintptr_t addr, char *buf, size_t size) {
 
-  uintptr_t end_addr = addr + size;
-  size_t words = (end_addr - addr) / sizeof(int);
+  struct ptrace_io_desc piod = {
+    .piod_op = PIOD_READ_D,
+    .piod_offs = (void *) addr,
+    .piod_addr = (void *) buf,
+    .piod_len = size
+  };
 
-  for (size_t i = 0; i < words; i++) {
-    errno = 0;
-    int rslt = ptrace(PT_READ_D, ph->pid, (caddr_t) addr, 0);
-    if (errno) {
-      print_error("ptrace(PT_READ_D, ..) failed with errno = %d for %d bytes @ %lx\n", errno, size, addr);
-      return false;
-    }
-    *(int *)buf = rslt;
-    buf += sizeof(int);
-    addr += sizeof(int);
+  errno = 0;
+  int rc = ptrace(PT_IO, ph->pid, (caddr_t) &piod, 0);
+
+  if (rc < 0 || errno != 0) {
+    print_error("ptrace(PT_IO, ..) failed with errno = %d for %d bytes @ %lx, %d bytes read\n",
+        errno, size, addr, piod.piod_len);
+    return false;
   }
 
-  if (addr < end_addr) {
-    int rslt;
-    char *ptr = (char *)&rslt;
-    errno = 0;
-    rslt = ptrace(PT_READ_D, ph->pid, (caddr_t) addr, 0);
-    if (errno) {
-      print_error("ptrace(PT_READ_D, ..) failed with errno = %d for remaining %d bytes @ %lx\n", errno, end_addr - addr, addr);
-      return false;
-    }
-    for (; addr != end_addr; addr++)
-       *(buf++) = *(ptr++);
+  if (piod.piod_len < size) {
+    print_error("ptrace(PT_IO, ..) failed to read %d bytes @ %lx, %d bytes read\n",
+        size, addr, piod.piod_len);
+    return false;
   }
+
   return true;
 }
 


### PR DESCRIPTION
This is an alternative fix for the FreeBSD Serviceability Agent. It does _not_ try to align the code with the workarounds made for MacOS, but is based more directly on the existing BSD implementation.

There's both advantages and disadvantages to this:

- The BSD implementation is simpler and more straight forward. Slightly fewer JNI/Java calls.
- `ptrace(PT_GETREGS, lwpid, ...)` seems more stable. Other `ptrace` calls may still fail now and again though.
- System support is handled the same for both live debuggees and coredumps. (I.e. no need to add PPC64 support to code imported from MacOS.)
- The java implementation of BsdDebuggerLocal contains code and workarounds not used by actual BSD's, only by MacOS.

This branch also seems to perform the same on x86_64 and Aarch64. The same tests may sporadically fail on both architectures, but at least it's consistent between them.