### PR TITLE
Sync constructors for ThreadWXEnable with MacOS impl

### DIFF
--- a/src/hotspot/share/runtime/threadWXSetters.inline.hpp
+++ b/src/hotspot/share/runtime/threadWXSetters.inline.hpp
@@ -120,8 +120,8 @@ public:
 class ThreadWXEnable  {
   WXMode _new_mode;
 public:
-  ThreadWXEnable(WXMode new_mode, Thread*) :
-    _new_mode(new_mode)
+  ThreadWXEnable(WXMode * new_mode, Thread*) :
+    _new_mode(*new_mode)
   {
     if (_new_mode == WXExec) {
       // We are going to execute some code that has been potentially
@@ -130,6 +130,12 @@ public:
                             "isb\tsy" : : : "memory");
     }
   }
+
+  ThreadWXEnable(WXMode new_mode, Thread * t)
+  {
+    ThreadWXEnable(&new_mode, t);
+  }
+
   ~ThreadWXEnable() {
     if (_new_mode == WXWrite) {
       // We may have modified some code that is going to be executed


### PR DESCRIPTION
Adds missing constructor taking WXMode arg as a pointer to the BSD implementation of ThreadWXEnable.

This work was sponsored by: The FreeBSD Foundation