### PR TITLE
Enable hsdis for FreeBSD

### DIFF
--- a/make/Hsdis.gmk
+++ b/make/Hsdis.gmk
@@ -62,6 +62,8 @@ ifeq ($(HSDIS_BACKEND), llvm)
     LLVM_OS := apple-darwin
   else ifeq ($(call isTargetOs, windows), true)
     LLVM_OS := pc-windows-msvc
+  else ifeq ($(call isTargetOsEnv, bsd.freebsd), true)
+    LLVM_OS := unknown-freebsd
   else
     $(error No support for LLVM on this platform)
   endif


### PR DESCRIPTION
The Hotspot Disassembler is used in some tests on Aarch64 to verify that the compiler generates the correct near and far call instruction sequences.

This patch enables using the LLVM backend for HSDIS by adding `--with-hsdis=llvm` to the configure args. See the HSDIS readme in `src/utils/hsdis/README.md` for information on how to build and install the HSDIS library to make it available for the JDK under test.

To build and use HSDIS, the llvm port needs to be installed. The llvm components in the base OS is not enough.

This work was sponsored by: The FreeBSD Foundation