### PR TITLE
Fix flakey SA test for FreeBSD

### DIFF
--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/bsd/BsdCDebugger.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/bsd/BsdCDebugger.java
@@ -39,9 +39,11 @@ import sun.jvm.hotspot.utilities.*;
 
 class BsdCDebugger implements CDebugger {
   private BsdDebugger dbg;
+  private boolean isDarwin;             // variant for MacOS
 
   BsdCDebugger(BsdDebugger dbg) {
     this.dbg = dbg;
+    this.isDarwin = PlatformInfo.getOS().equals("darwin");
   }
 
   public List<ThreadProxy> getThreadList() throws DebuggerException {
@@ -56,30 +58,46 @@ class BsdCDebugger implements CDebugger {
     if (pc == null) {
       return null;
     }
-    List<LoadObject> objs = getLoadObjectList();
-    Object[] arr = objs.toArray();
-    // load objects are sorted by base address, do binary search
-    int mid  = -1;
-    int low  = 0;
-    int high = arr.length - 1;
 
-    while (low <= high) {
-       mid = (low + high) >> 1;
-       LoadObject midVal = (LoadObject) arr[mid];
-       long cmp = pc.minus(midVal.getBase());
-       if (cmp < 0) {
-          high = mid - 1;
-       } else if (cmp > 0) {
-          long size = midVal.getSize();
-          if (cmp >= size) {
-             low = mid + 1;
-          } else {
-             return (LoadObject) arr[mid];
-          }
-       } else { // match found
-          return (LoadObject) arr[mid];
-       }
+    List<LoadObject> objs = getLoadObjectList();
+    if (isDarwin) {
+      Object[] arr = objs.toArray();
+      // load objects are sorted by base address, do binary search
+      int mid  = -1;
+      int low  = 0;
+      int high = arr.length - 1;
+
+      while (low <= high) {
+         mid = (low + high) >> 1;
+         LoadObject midVal = (LoadObject) arr[mid];
+         long cmp = pc.minus(midVal.getBase());
+         if (cmp < 0) {
+            high = mid - 1;
+         } else if (cmp > 0) {
+            long size = midVal.getSize();
+            if (cmp >= size) {
+               low = mid + 1;
+            } else {
+               return (LoadObject) arr[mid];
+            }
+         } else { // match found
+            return (LoadObject) arr[mid];
+         }
+      }
+    } else {
+      /* Typically we have about ten loaded objects here. So no reason to do
+        sort/binary search here. Linear search gives us acceptable performance.
+        This also works more reliably on BSD.*/
+      for (int i = 0; i < objs.size(); i++) {
+        LoadObject ob = objs.get(i);
+        Address base = ob.getBase();
+        long size = ob.getSize();
+        if (pc.greaterThanOrEqual(base) && pc.lessThan(base.addOffsetTo(size))) {
+          return ob;
+        }
+      }
     }
+
     // no match found.
     return null;
   }


### PR DESCRIPTION
The ClhsdbFindPC tests have been flakey on FreeBSD, where one or two tests have been failing most of the time, but not always. I traced this down to the logic for finding which load object (.so file) an address belongs to.

The BSD implementation would do a binary search over the loaded objects, which assumes the objects are sorted by their address space. This appears to not be the case on FreeBSD at least.

Given that we're unlikely to have millions of loaded objects in a process in any case, we should be fine with just a linear search through the objects. This is also what's done for Linux.

I've kept the existing binary search implementation for MacOS, but the BSDs will now just do a plain linear search.

This work was sponsored by: The FreeBSD Foundation