### PR TITLE
Adjust FreeBSD Hsdis support to apply to *BSD.

### DIFF
--- a/make/Hsdis.gmk
+++ b/make/Hsdis.gmk
@@ -62,8 +62,8 @@ ifeq ($(HSDIS_BACKEND), llvm)
     LLVM_OS := apple-darwin
   else ifeq ($(call isTargetOs, windows), true)
     LLVM_OS := pc-windows-msvc
-  else ifeq ($(call isTargetOsEnv, bsd.freebsd), true)
-    LLVM_OS := unknown-freebsd
+  else ifeq ($(call isTargetOs, bsd), true)
+    LLVM_OS := unknown-$(OPENJDK_TARGET_OS_ENV:bsd.%=%)
   else
     $(error No support for LLVM on this platform)
   endif


### PR DESCRIPTION
Tested on OpenBSD/aarch64. I would prefer this version be upstreamed in bsd-port [PR 6](https://github.com/openjdk/bsd-port/pull/6). If it looks good for FreeBSD too.