### PR TITLE
Add missing call to StubGenerator::generate_atomic_entry_points

### DIFF
--- a/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
@@ -10261,7 +10261,7 @@ class StubGenerator: public StubCodeGenerator {
     return start;
   }
 
-#if (defined (LINUX) && !defined (__ARM_FEATURE_ATOMICS)) || defined(_BSDONLY_SOURCE)
+#if (defined (LINUX) || defined(_BSDONLY_SOURCE)) && !defined (__ARM_FEATURE_ATOMICS)
 
   // ARMv8.1 LSE versions of the atomic stubs used by AtomicAccess::PlatformXX.
   //
@@ -11727,11 +11727,11 @@ class StubGenerator: public StubCodeGenerator {
     StubRoutines::_upcall_stub_exception_handler = generate_upcall_stub_exception_handler();
     StubRoutines::_upcall_stub_load_target = generate_upcall_stub_load_target();
 
-#if defined (LINUX) && !defined (__ARM_FEATURE_ATOMICS)
+#if (defined (LINUX) || defined(_BSDONLY_SOURCE) && !defined (__ARM_FEATURE_ATOMICS))
 
     generate_atomic_entry_points();
 
-#endif // LINUX
+#endif // LINUX || _BSDONLY_SOURCE
 
 #ifdef COMPILER2
     if (UseSecondarySupersTable) {

--- a/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
@@ -11727,7 +11727,7 @@ class StubGenerator: public StubCodeGenerator {
     StubRoutines::_upcall_stub_exception_handler = generate_upcall_stub_exception_handler();
     StubRoutines::_upcall_stub_load_target = generate_upcall_stub_load_target();
 
-#if (defined (LINUX) || defined(_BSDONLY_SOURCE) && !defined (__ARM_FEATURE_ATOMICS))
+#if (defined (LINUX) || defined(_BSDONLY_SOURCE)) && !defined (__ARM_FEATURE_ATOMICS)
 
     generate_atomic_entry_points();
 


### PR DESCRIPTION
and correct use of __ARM_FEATURE_ATOMICS for _BSDONLY_SOURCE.

I was doing a code review of the BSD aarch64 support and comparing to linux aarch64 support and reviewing all places that were `LINUX` only to see if we were missing anything. In that review I noticed in src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp that there was a discrepancy with our use of  `_BSDONLY_SOURCE` in this file. In one place we changed:

```
-#if defined (LINUX) && !defined (__ARM_FEATURE_ATOMICS)
+#if (defined (LINUX) && !defined (__ARM_FEATURE_ATOMICS)) || defined(_BSDONLY_SOURCE)
```

Later the code was changed to have second place where `#if defined (LINUX) && !defined (__ARM_FEATURE_ATOMICS)` was introduced but we didn't make the corresponding change which results in BSD support not calling `StubGenerator::generate_atomic_entry_points` which is needed for hardware that support `HWCAP_ATOMICS` (e.g. `UseLSE`).

The addition of `_BSDONLY_SOURCE` also looked suspect to me as it was not taking into account if `__ARM_FEATURE_ATOMICS` was defined or not. Looking into `__ARM_FEATURE_ATOMICS` I found the following. This is compiler define that is set if `-march=armv8.1-a` is set (or higher) while compiling. It means the generated assembly assumes the CPU has `HWCAP_ATOMICS` and can use instructions only available on CPUs that have it. On at least OpenBSD & FreeBSD it is **not** set by default which can be checked with:

```
m2$ echo __ARM_FEATURE_ATOMICS | clang -v -E - 2>&1 | tail -n 1
__ARM_FEATURE_ATOMICS
m2$ echo __ARM_FEATURE_ATOMICS | clang -march=armv8.1-a -v -E - 2>&1 | tail -n 1
1
```

What does this mean? The jdk has support for if you compile it with `-march=armv8.1-a`. This can be seen by greping for `__ARM_FEATURE_ATOMICS` in the aarch64 code. However, if not compiled with that support it relies on `HWCAP_ATOMICS` runtime detection to set `UseLSE`.

I explain all this to justify the change where `_BSDONLY_SOURCE` should match `LINUX` in its handling of `__ARM_FEATURE_ATOMICS` and use:

```
#if (defined (LINUX) || defined(_BSDONLY_SOURCE)) && !defined (__ARM_FEATURE_ATOMICS)
```

I don't have a specific test that I can point to that this fixes, but I believe this analysis does justify this PR. 

Edited to fix parentheses in code example.