### PR TITLE
OpenBSD fixes and cleanups for aarch64

### DIFF
--- a/make/hotspot/lib/JvmOverrideFiles.gmk
+++ b/make/hotspot/lib/JvmOverrideFiles.gmk
@@ -189,9 +189,9 @@ else ifeq ($(call isTargetOs, bsd), true)
         parse2.cpp \
         #
 
-    ifeq ($(OPENJDK_TARGET_CPU), aarch64)
+    ifeq ($(call isTargetCpu, aarch64), true)
       JVM_PRECOMPILED_HEADER_EXCLUDE += \
-          memnode.cpp
+          memnode.cpp \
           #
       BUILD_LIBJVM_memnode.cpp_CXXFLAGS := -O0
     endif

--- a/make/hotspot/lib/JvmOverrideFiles.gmk
+++ b/make/hotspot/lib/JvmOverrideFiles.gmk
@@ -197,7 +197,7 @@ else ifeq ($(call isTargetOs, bsd), true)
     endif
 
     # retguard interferes with these files leading to SIGTRAP
-    ifeq ($(call isTargetOsEnv, bsd.openbsd), true)
+    ifeq ($(call isTargetOsEnv, bsd.openbsd)+$(call isTargetCpu, x86_64), true+true)
       JVM_PRECOMPILED_HEADER_EXCLUDE += \
           c1_Runtime1.cpp \
           sharedRuntime.cpp \

--- a/src/hotspot/os_cpu/bsd_aarch64/os_bsd_aarch64.cpp
+++ b/src/hotspot/os_cpu/bsd_aarch64/os_bsd_aarch64.cpp
@@ -230,7 +230,7 @@ intptr_t* os::fetch_bcp_from_context(const void* ucVoid) {
 
 // JVM compiled with -fno-omit-frame-pointer, so RFP is saved on the stack.
 frame os::get_sender_for_C_frame(frame* fr) {
-#ifdef __FreeBSD__
+#if !defined(__APPLE__)
   address pc = fr->sender_pc();
   CodeBlob* cb = CodeCache::find_blob(pc);
   bool use_codeblob = cb != nullptr && cb->frame_size() > 0;

--- a/src/hotspot/os_cpu/bsd_aarch64/pauth_bsd_aarch64.inline.hpp
+++ b/src/hotspot/os_cpu/bsd_aarch64/pauth_bsd_aarch64.inline.hpp
@@ -28,20 +28,64 @@
 // OS specific Support for ROP Protection in VM code.
 // For more details on PAC see pauth_aarch64.hpp.
 
+#ifdef __OpenBSD__
+inline bool pauth_ptr_is_raw(address ptr);
+
+// Write these instructions using their alternate "hint" instructions to
+// ensure older compilers can still be used.
+#define XPACLRI "hint #0x7;"
+#define PACIAZ  "hint #0x18;"
+#define AUTIAZ  "hint #0x1c;"
+#endif
+
+// Strip an address. Use with caution -
+// only if there is no guaranteed way of authenticating the value.
+//
 inline address pauth_strip_pointer(address ptr) {
-  // No PAC support in BSD as of yet.
+#ifdef __OpenBSD__
+  register address result __asm__("x30") = ptr;
+  asm (XPACLRI : "+r"(result));
+  return result;
+#else
   return ptr;
+#endif // OpenBSD
 }
 
+// Sign a return value, using value zero as the modifier.
+//
 inline address pauth_sign_return_address(address ret_addr) {
-  // No PAC support in BSD as of yet.
+#ifdef __OpenBSD__
+  if (VM_Version::use_rop_protection()) {
+    // A pointer cannot be double signed.
+    guarantee(pauth_ptr_is_raw(ret_addr), "Return address is already signed");
+    register address reg30 __asm__("x30") = ret_addr;
+    asm (PACIAZ : "+r"(reg30));
+    ret_addr = reg30;
+  }
+#endif
   return ret_addr;
 }
 
+// Authenticate a return value, using value zero as the modifier.
+//
 inline address pauth_authenticate_return_address(address ret_addr) {
-  // No PAC support in BSD as of yet.
+#ifdef __OpenBSD__
+  if (VM_Version::use_rop_protection()) {
+    register address reg30 __asm__("x30") = ret_addr;
+    asm (AUTIAZ : "+r"(reg30));
+    ret_addr = reg30;
+    // Ensure that the pointer authenticated.
+    guarantee(pauth_ptr_is_raw(ret_addr),
+              "Return address did not authenticate");
+  }
+#endif
   return ret_addr;
 }
+
+#ifdef __OpenBSD__
+#undef XPACLRI
+#undef PACIAZ
+#undef AUTIAZ
+#endif
 
 #endif // OS_CPU_BSD_AARCH64_PAUTH_BSD_AARCH64_INLINE_HPP
-


### PR DESCRIPTION
This fixes a few OpenBSD/aarch64 test failures that relate to inspecting the stack. OpenBSD's clang on aarch64 has pointer authentication enabled by default so I needed to port over the linux support for that to correct those test cases. Also while here I tested the retguard disabling for OpenBSD is only needed for amd64, and some makefile style cleanups.