### PR TITLE
Sync BSD GHA with recent changes

### DIFF
--- a/.github/actions/do-build-vm/action.yml
+++ b/.github/actions/do-build-vm/action.yml
@@ -75,7 +75,7 @@ runs:
       shell: bash
 
     - name: 'Upload build logs'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: failure-logs-${{ inputs.platform }}${{ inputs.debug-suffix }}
         path: failure-logs
@@ -83,7 +83,7 @@ runs:
 
       # This is the best way I found to abort the job with an error message
     - name: 'Notify about build failures'
-      uses: actions/github-script@v7
+      uses: actions/github-script@v8
       with:
         script: core.setFailed('Build failed. See summary for details.')
       if: steps.check.outputs.failure == 'true'

--- a/.github/workflows/build-freebsd.yml
+++ b/.github/workflows/build-freebsd.yml
@@ -145,7 +145,7 @@ jobs:
           --with-zlib=system
           --with-jmod-compress=zip-1
           --with-external-symbols-in-bundles=none
-          --with-debug-info-level=1
+          --with-native-debug-symbols-level=1
           --with-stdc++lib=dynamic
           --with-toolchain-type=clang
           --with-fontconfig=/usr/local

--- a/.github/workflows/build-freebsd.yml
+++ b/.github/workflows/build-freebsd.yml
@@ -92,7 +92,7 @@ jobs:
           sudo df -h
 
       - name: 'Checkout the JDK source'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: 'Set the BootJDK path'
         id: bootjdk

--- a/.github/workflows/build-freebsd.yml
+++ b/.github/workflows/build-freebsd.yml
@@ -144,6 +144,7 @@ jobs:
           --with-gtest=${{ steps.gtest.outputs.path }}
           --with-zlib=system
           --with-jmod-compress=zip-1
+          --with-external-symbols-in-bundles=none
           --with-stdc++lib=dynamic
           --with-toolchain-type=clang
           --with-fontconfig=/usr/local

--- a/.github/workflows/build-freebsd.yml
+++ b/.github/workflows/build-freebsd.yml
@@ -145,6 +145,7 @@ jobs:
           --with-zlib=system
           --with-jmod-compress=zip-1
           --with-external-symbols-in-bundles=none
+          --with-debug-info-level=1
           --with-stdc++lib=dynamic
           --with-toolchain-type=clang
           --with-fontconfig=/usr/local

--- a/.github/workflows/build-openbsd.yml
+++ b/.github/workflows/build-openbsd.yml
@@ -155,7 +155,7 @@ jobs:
           --with-zlib=system
           --with-jmod-compress=zip-1
           --with-external-symbols-in-bundles=none
-          --with-debug-info-level=1
+          --with-native-debug-symbols-level=1
           --with-stdc++lib=dynamic
           --with-toolchain-type=clang
           --with-fontconfig=/usr/X11R6

--- a/.github/workflows/build-openbsd.yml
+++ b/.github/workflows/build-openbsd.yml
@@ -92,7 +92,7 @@ jobs:
           sudo df -h
 
       - name: 'Checkout the JDK source'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: 'Get the BootJDK'
         id: bootjdk
@@ -110,7 +110,7 @@ jobs:
 
       - name: 'Restore Cached VM Packages'
         id: vm-packages-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: obsd-pkg-cache
           key: packages-${{ inputs.platform }}-${{ inputs.vm-release }}-${{ inputs.vm-arch }}-${{ hashFiles('./obsd-pkg-cache/*.tgz') }}
@@ -193,7 +193,7 @@ jobs:
           sudo df -h
 
       - name: 'Save VM Packages'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: obsd-pkg-cache
           key: packages-${{ inputs.platform }}-${{ inputs.vm-release }}-${{ inputs.vm-arch }}-${{ hashFiles('./obsd-pkg-cache/*.tgz') }}

--- a/.github/workflows/build-openbsd.yml
+++ b/.github/workflows/build-openbsd.yml
@@ -155,6 +155,7 @@ jobs:
           --with-zlib=system
           --with-jmod-compress=zip-1
           --with-external-symbols-in-bundles=none
+          --with-debug-info-level=1
           --with-stdc++lib=dynamic
           --with-toolchain-type=clang
           --with-fontconfig=/usr/X11R6

--- a/.github/workflows/build-openbsd.yml
+++ b/.github/workflows/build-openbsd.yml
@@ -154,6 +154,7 @@ jobs:
           --with-gtest=${{ steps.gtest.outputs.path }}
           --with-zlib=system
           --with-jmod-compress=zip-1
+          --with-external-symbols-in-bundles=none
           --with-stdc++lib=dynamic
           --with-toolchain-type=clang
           --with-fontconfig=/usr/X11R6

--- a/.github/workflows/test-freebsd.yml
+++ b/.github/workflows/test-freebsd.yml
@@ -137,7 +137,7 @@ jobs:
           sudo df -h
 
       - name: 'Checkout the JDK source'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: 'Set the BootJDK path'
         id: bootjdk
@@ -250,7 +250,7 @@ jobs:
         if: always()
 
       - name: 'Upload test results'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           path: results
           name: ${{ steps.package.outputs.artifact-name }}
@@ -258,7 +258,7 @@ jobs:
 
         # This is the best way I found to abort the job with an error message
       - name: 'Notify about test failures'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: core.setFailed('${{ steps.run-tests.outputs.error-message }}')
         if: steps.run-tests.outputs.failure == 'true'

--- a/.github/workflows/test-openbsd.yml
+++ b/.github/workflows/test-openbsd.yml
@@ -139,7 +139,7 @@ jobs:
           sudo df -h
 
       - name: 'Checkout the JDK source'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: 'Get the BootJDK'
         id: bootjdk
@@ -182,7 +182,7 @@ jobs:
 
       - name: Restore Cached VM Packages
         id: vm-packages-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: obsd-pkg-cache
           key: packages-${{ inputs.platform }}-${{ inputs.vm-release }}-${{ inputs.vm-arch }}-${{ hashFiles('./obsd-pkg-cache/*.tgz') }}
@@ -263,7 +263,7 @@ jobs:
         if: always()
 
       - name: 'Upload test results'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           path: results
           name: ${{ steps.package.outputs.artifact-name }}
@@ -271,7 +271,7 @@ jobs:
 
         # This is the best way I found to abort the job with an error message
       - name: 'Notify about test failures'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: core.setFailed('${{ steps.run-tests.outputs.error-message }}')
         if: steps.run-tests.outputs.failure == 'true'


### PR DESCRIPTION
Sync up BSD GHA support with recent changes to other OS. Fixes `Node.js 20 actions are deprecated.` warnings.