### PR TITLE
Remove duplicate include in global defs for zero

### DIFF
--- a/src/hotspot/cpu/zero/globalDefinitions_zero.hpp
+++ b/src/hotspot/cpu/zero/globalDefinitions_zero.hpp
@@ -38,8 +38,6 @@
 
 #include <ffi.h>
 
-#include <ffi.h>
-
 // Indicates whether the C calling conventions require that
 // 32-bit integer argument values are extended to 64 bits.
 const bool CCallingConventionRequiresIntsAsLongs = false;


### PR DESCRIPTION
Trivial change removing duplicate include of ffi.h that somehow snuck into the BSD port.

This work is sponsored by The FreeBSD Foundation




---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).
