### PR TITLE
GHA: OpenBSD 7.9

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -408,7 +408,7 @@ jobs:
       platform: openbsd-x64
       runs-on: ubuntu-24.04
       vm-arch: 'x86_64'
-      vm-release: "7.8"
+      vm-release: "7.9"
       configure-arguments: ${{ github.event.inputs.configure-arguments }}
       make-arguments: ${{ github.event.inputs.make-arguments }}
       dry-run: ${{ needs.prepare.outputs.dry-run == 'true' }}
@@ -512,7 +512,7 @@ jobs:
     with:
       platform: openbsd-x64
       runs-on: ubuntu-24.04
-      vm-release: 7.8
+      vm-release: 7.9
       vm-arch: x86_64
       dry-run: ${{ needs.prepare.outputs.dry-run == 'true' }}
       debug-suffix: -debug

--- a/.github/workflows/test-openbsd.yml
+++ b/.github/workflows/test-openbsd.yml
@@ -82,7 +82,6 @@ jobs:
         include:
           - test-name: 'jdk/tier1 part 1'
             test-suite: 'test/jdk/:tier1_part1'
-            test-timeout-factor: 'TIMEOUT_FACTOR=4'
 
           - test-name: 'jdk/tier1 part 2'
             test-suite: 'test/jdk/:tier1_part2'
@@ -119,7 +118,6 @@ jobs:
 
           - test-name: 'hs/tier1 serviceability'
             test-suite: 'test/hotspot/jtreg/:tier1_serviceability'
-            test-timeout-factor: 'TIMEOUT_FACTOR=2'
             debug-suffix: ${{ inputs.debug-suffix }}
 
           - test-name: 'lib-test/tier1'
@@ -209,7 +207,6 @@ jobs:
           run: >
             ulimit -Sd $(ulimit -Hd) &&
             gmake test-prebuilt
-            TEST_JOBS=1
             TEST='${{ matrix.test-suite }}'
             BOOT_JDK=${{ steps.bootjdk.outputs.path }}
             JT_HOME=${{ steps.jtreg.outputs.path }}
@@ -218,7 +215,7 @@ jobs:
             TEST_IMAGE_DIR=${{ steps.bundles.outputs.tests-path }}
             ${{ steps.extra-options.outputs.test-jdk }}
             ${{ steps.extra-options.outputs.compile-jdk }}
-            JTREG='JAVA_OPTIONS=-XX:-CreateCoredumpOnCrash;VERBOSE=fail,error,time;KEYWORDS=!headful;${{ steps.extra-options.outputs.extra-problem-lists }};${{ matrix.test-timeout-factor }}'
+            JTREG='JAVA_OPTIONS=-XX:-CreateCoredumpOnCrash;VERBOSE=fail,error,time;KEYWORDS=!headful;${{ steps.extra-options.outputs.extra-problem-lists }}'
             && bash ./.github/scripts/gen-test-summary.sh "$GITHUB_STEP_SUMMARY" "$GITHUB_OUTPUT"
         if: ${{ inputs.dry-run == false }}
 

--- a/make/conf/github-actions.conf
+++ b/make/conf/github-actions.conf
@@ -53,5 +53,5 @@ WINDOWS_X64_BOOT_JDK_URL=https://download.java.net/java/GA/jdk26/c3cc523845074aa
 WINDOWS_X64_BOOT_JDK_SHA256=2dd2d92c9374cd49a120fe9d916732840bf6bb9f0e0cc29794917a3c08b99c5f
 
 OPENBSD_X64_BOOT_JDK_EXT=tar.gz
-OPENBSD_X64_BOOT_JDK_URL=https://www.intricatesoftware.com/distfiles/jdk-openbsd-x64-7.8-dc931d7.tar.gz
-OPENBSD_X64_BOOT_JDK_SHA256=64c9a64e11d3f8e68659c333ddacb8f7178f8ccda9d0a527387bd8415fc8848c
+OPENBSD_X64_BOOT_JDK_URL=https://www.intricatesoftware.com/distfiles/jdk-openbsd-x64-7.9-dc931d7.tar.gz
+OPENBSD_X64_BOOT_JDK_SHA256=18c5656c13c21ea6f38a6fd223ce328943b1ee98d0fcf2ee57f0b1ecd3389696


### PR DESCRIPTION
Update OpenBSD build and test to use 7.9 release. Also remove some unneeded work-arounds when testing OpenBSD.