### PR TITLE
Remove ThreadWXEnable from BSD code

### DIFF
--- a/src/hotspot/cpu/aarch64/jniFastGetField_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/jniFastGetField_aarch64.cpp
@@ -58,7 +58,7 @@ static const Register result        = r7;
 // (8262896).  So each FastGetXXXField is wrapped into a C++ statically
 // compiled template function that optionally switches to WXExec if necessary.
 
-#ifdef _ALLBSD_SOURCE
+#ifdef __APPLE__
 
 static address generated_fast_get_field[T_LONG + 1 - T_BOOLEAN];
 
@@ -86,14 +86,14 @@ address JNI_FastGetField::generate_fast_get_int_field1() {
   return (address)static_fast_get_field_wrapper<BType>;
 }
 
-#else // _ALLBSD_SOURCE
+#else // __APPLE__
 
 template<int BType>
 address JNI_FastGetField::generate_fast_get_int_field1() {
   return generate_fast_get_int_field0((BasicType)BType);
 }
 
-#endif // _ALLBSD_SOURCE
+#endif // __APPLE__
 
 address JNI_FastGetField::generate_fast_get_int_field0(BasicType type) {
   const char *name;

--- a/src/hotspot/share/c1/c1_Runtime1.cpp
+++ b/src/hotspot/share/c1/c1_Runtime1.cpp
@@ -1307,7 +1307,7 @@ void Runtime1::patch_code(JavaThread* current, StubId stub_id) {
 
   // Enable WXWrite: the function is called by c1 stub as a runtime function
   // (see another implementation above).
-  BSD_AARCH64_ONLY(ThreadWXEnable wx(WXWrite, current));
+  MACOS_AARCH64_ONLY(ThreadWXEnable wx(WXWrite, current));
 
   if (TracePatching) {
     tty->print_cr("Deoptimizing because patch is needed");

--- a/src/hotspot/share/gc/shared/barrierSetNMethod.cpp
+++ b/src/hotspot/share/gc/shared/barrierSetNMethod.cpp
@@ -174,7 +174,7 @@ void BarrierSetNMethod::arm_all_nmethods() {
 int BarrierSetNMethod::nmethod_stub_entry_barrier(address* return_address_ptr) {
   // Enable WXWrite: the function is called directly from nmethod_entry_barrier
   // stub.
-  BSD_AARCH64_ONLY(ThreadWXEnable wx(WXWrite, Thread::current()));
+  MACOS_AARCH64_ONLY(ThreadWXEnable wx(WXWrite, Thread::current()));
 
   address return_address = *return_address_ptr;
   AARCH64_PORT_ONLY(return_address = pauth_strip_pointer(return_address));

--- a/src/hotspot/share/gc/shenandoah/shenandoahBarrierSetNMethod.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahBarrierSetNMethod.cpp
@@ -51,7 +51,7 @@ bool ShenandoahBarrierSetNMethod::nmethod_entry_barrier(nmethod* nm) {
     return true;
   }
 
-  BSD_AARCH64_ONLY(ThreadWXEnable wx(WXWrite, Thread::current());)
+  MACOS_AARCH64_ONLY(ThreadWXEnable wx(WXWrite, Thread::current());)
 
   if (nm->is_unloading()) {
     // We don't need to take the lock when unlinking nmethods from

--- a/src/hotspot/share/gc/z/zBarrierSetNMethod.cpp
+++ b/src/hotspot/share/gc/z/zBarrierSetNMethod.cpp
@@ -56,7 +56,7 @@ bool ZBarrierSetNMethod::nmethod_entry_barrier(nmethod* nm) {
     return true;
   }
 
-  BSD_AARCH64_ONLY(ThreadWXEnable wx(WXWrite, Thread::current()));
+  MACOS_AARCH64_ONLY(ThreadWXEnable wx(WXWrite, Thread::current()));
 
   if (nm->is_unloading()) {
     log_develop_trace(gc, nmethod)("nmethod: " PTR_FORMAT " visited by entry (unloading)", p2i(nm));

--- a/src/hotspot/share/interpreter/interpreterRuntime.cpp
+++ b/src/hotspot/share/interpreter/interpreterRuntime.cpp
@@ -1007,7 +1007,7 @@ JRT_END
 
 nmethod* InterpreterRuntime::frequency_counter_overflow(JavaThread* current, address branch_bcp) {
   // Enable WXWrite: the function is called directly by interpreter.
-  BSD_AARCH64_ONLY(ThreadWXEnable wx(WXWrite, current));
+  MACOS_AARCH64_ONLY(ThreadWXEnable wx(WXWrite, current));
 
   // frequency_counter_overflow_inner can throw async exception.
   nmethod* nm = frequency_counter_overflow_inner(current, branch_bcp);

--- a/src/hotspot/share/jfr/instrumentation/jfrJvmtiAgent.cpp
+++ b/src/hotspot/share/jfr/instrumentation/jfrJvmtiAgent.cpp
@@ -143,7 +143,7 @@ void JfrJvmtiAgent::retransform_classes(JNIEnv* env, jobjectArray classes_array,
   }
   ResourceMark rm(THREAD);
   // WXWrite is needed before entering the vm below and in callee methods.
-  BSD_AARCH64_ONLY(ThreadWXEnable __wx(WXWrite, THREAD));
+  MACOS_AARCH64_ONLY(ThreadWXEnable __wx(WXWrite, THREAD));
   jclass* const classes = create_classes_array(classes_count, CHECK);
   assert(classes != nullptr, "invariant");
   for (jint i = 0; i < classes_count; i++) {

--- a/src/hotspot/share/jfr/jni/jfrJniMethod.cpp
+++ b/src/hotspot/share/jfr/jni/jfrJniMethod.cpp
@@ -103,7 +103,7 @@ NO_TRANSITION(void, jfr_set_enabled(JNIEnv* env, jclass jvm, jlong event_type_id
   JfrEventSetting::set_enabled(event_type_id, JNI_TRUE == enabled);
   if (EventOldObjectSample::eventId == event_type_id) {
     JavaThread* thread = JavaThread::thread_from_jni_environment(env);
-    BSD_AARCH64_ONLY(ThreadWXEnable __wx(WXWrite, thread));
+    MACOS_AARCH64_ONLY(ThreadWXEnable __wx(WXWrite, thread));
     ThreadInVMfromNative transition(thread);
     if (JNI_TRUE == enabled) {
       LeakProfiler::start(JfrOptionSet::old_object_queue_size());

--- a/src/hotspot/share/jfr/recorder/storage/jfrStorage.cpp
+++ b/src/hotspot/share/jfr/recorder/storage/jfrStorage.cpp
@@ -290,7 +290,7 @@ void JfrStorage::register_full(BufferPtr buffer, Thread* thread) {
       JavaThread* jt = JavaThread::cast(thread);
       if (jt->thread_state() == _thread_in_native) {
         // Transition java thread to vm so it can issue a notify.
-        BSD_AARCH64_ONLY(ThreadWXEnable __wx(WXWrite, jt));
+        MACOS_AARCH64_ONLY(ThreadWXEnable __wx(WXWrite, jt));
         ThreadInVMfromNative transition(jt);
         _post_box.post(MSG_FULLBUFFER);
         return;

--- a/src/hotspot/share/jfr/support/jfrIntrinsics.cpp
+++ b/src/hotspot/share/jfr/support/jfrIntrinsics.cpp
@@ -44,7 +44,7 @@ void* JfrIntrinsicSupport::write_checkpoint(JavaThread* jt) {
   assert(JfrThreadLocal::is_vthread(jt), "invariant");
   const traceid vthread_tid = JfrThreadLocal::vthread_id(jt);
   // Transition before reading the epoch generation, now as _thread_in_vm.
-  BSD_AARCH64_ONLY(ThreadWXEnable __wx(WXWrite, jt));
+  MACOS_AARCH64_ONLY(ThreadWXEnable __wx(WXWrite, jt));
   ThreadInVMfromJava transition(jt);
   JfrThreadLocal::set_vthread_epoch(jt, vthread_tid, ThreadIdAccess::current_epoch());
   return JfrJavaEventWriter::event_writer(jt);
@@ -52,7 +52,7 @@ void* JfrIntrinsicSupport::write_checkpoint(JavaThread* jt) {
 
 void* JfrIntrinsicSupport::return_lease(JavaThread* jt) {
   DEBUG_ONLY(assert_precondition(jt);)
-  BSD_AARCH64_ONLY(ThreadWXEnable __wx(WXWrite, jt));
+  MACOS_AARCH64_ONLY(ThreadWXEnable __wx(WXWrite, jt));
   ThreadInVMfromJava transition(jt);
   assert(jt->jfr_thread_local()->has_java_event_writer(), "invariant");
   assert(jt->jfr_thread_local()->shelved_buffer() != nullptr, "invariant");

--- a/src/hotspot/share/jfr/support/jfrNativeLibraryLoadEvent.cpp
+++ b/src/hotspot/share/jfr/support/jfrNativeLibraryLoadEvent.cpp
@@ -116,7 +116,7 @@ static void commit(const HelperType& helper) {
     JavaThread* jt = JavaThread::cast(thread);
     if (jt->thread_state() == _thread_in_native) {
       // For a JavaThread to take a JFR stacktrace, it must be in _thread_in_vm. Can safepoint here.
-      BSD_AARCH64_ONLY(ThreadWXEnable __wx(WXWrite, jt));
+      MACOS_AARCH64_ONLY(ThreadWXEnable __wx(WXWrite, jt));
       ThreadInVMfromNative transition(jt);
       event.commit();
       return;

--- a/src/hotspot/share/prims/jniCheck.cpp
+++ b/src/hotspot/share/prims/jniCheck.cpp
@@ -100,7 +100,7 @@ extern "C" {                                                             \
     if (env != xenv) {                                                   \
       NativeReportJNIFatalError(thr, warn_wrong_jnienv);                 \
     }                                                                    \
-    BSD_AARCH64_ONLY(ThreadWXEnable __wx(WXWrite, thr));               \
+    MACOS_AARCH64_ONLY(ThreadWXEnable __wx(WXWrite, thr));               \
     VM_ENTRY_BASE(result_type, header, thr)
 
 

--- a/src/hotspot/share/prims/jvmtiEnter.xsl
+++ b/src/hotspot/share/prims/jvmtiEnter.xsl
@@ -436,7 +436,7 @@ struct jvmtiInterface_1_ jvmti</xsl:text>
   <xsl:if test="count(@impl)=0 or not(contains(@impl,'innative'))">
     <xsl:text>JavaThread* current_thread = JavaThread::cast(this_thread);</xsl:text>
     <xsl:value-of select="$space"/>
-    <xsl:text>BSD_AARCH64_ONLY(ThreadWXEnable __wx(WXWrite, current_thread));</xsl:text>
+    <xsl:text>MACOS_AARCH64_ONLY(ThreadWXEnable __wx(WXWrite, current_thread));</xsl:text>
     <xsl:value-of select="$space"/>
     <xsl:text>ThreadInVMfromNative __tiv(current_thread);</xsl:text>
     <xsl:value-of select="$space"/>

--- a/src/hotspot/share/prims/jvmtiEnv.cpp
+++ b/src/hotspot/share/prims/jvmtiEnv.cpp
@@ -196,7 +196,7 @@ JvmtiEnv::GetThreadLocalStorage(jthread thread, void** data_ptr) {
     // other than the current thread is required we need to transition
     // from native so as to resolve the jthread.
 
-    BSD_AARCH64_ONLY(ThreadWXEnable __wx(WXWrite, current_thread));
+    MACOS_AARCH64_ONLY(ThreadWXEnable __wx(WXWrite, current_thread));
     ThreadInVMfromNative __tiv(current_thread);
     VM_ENTRY_BASE(jvmtiError, JvmtiEnv::GetThreadLocalStorage , current_thread)
     DEBUG_ONLY(VMNativeEntryWrapper __vew;)
@@ -3564,7 +3564,7 @@ JvmtiEnv::RawMonitorEnter(JvmtiRawMonitor * rmonitor) {
   } else {
     Thread* thread = Thread::current();
     // 8266889: raw_enter changes Java thread state, needs WXWrite
-    BSD_AARCH64_ONLY(ThreadWXEnable __wx(WXWrite, thread));
+    MACOS_AARCH64_ONLY(ThreadWXEnable __wx(WXWrite, thread));
     rmonitor->raw_enter(thread);
   }
   return JVMTI_ERROR_NONE;
@@ -3598,7 +3598,7 @@ jvmtiError
 JvmtiEnv::RawMonitorWait(JvmtiRawMonitor * rmonitor, jlong millis) {
   Thread* thread = Thread::current();
   // 8266889: raw_wait changes Java thread state, needs WXWrite
-  BSD_AARCH64_ONLY(ThreadWXEnable __wx(WXWrite, thread));
+  MACOS_AARCH64_ONLY(ThreadWXEnable __wx(WXWrite, thread));
   int r = rmonitor->raw_wait(millis, thread);
 
   switch (r) {

--- a/src/hotspot/share/prims/jvmtiExport.cpp
+++ b/src/hotspot/share/prims/jvmtiExport.cpp
@@ -403,7 +403,7 @@ JvmtiExport::get_jvmti_interface(JavaVM *jvm, void **penv, jint version) {
   if (JvmtiEnv::get_phase() == JVMTI_PHASE_LIVE) {
     JavaThread* current_thread = JavaThread::current();
     // transition code: native to VM
-    BSD_AARCH64_ONLY(ThreadWXEnable __wx(WXWrite, current_thread));
+    MACOS_AARCH64_ONLY(ThreadWXEnable __wx(WXWrite, current_thread));
     ThreadInVMfromNative __tiv(current_thread);
     VM_ENTRY_BASE(jvmtiEnv*, JvmtiExport::get_jvmti_interface, current_thread)
     DEBUG_ONLY(VMNativeEntryWrapper __vew;)

--- a/src/hotspot/share/prims/jvmtiExtensions.cpp
+++ b/src/hotspot/share/prims/jvmtiExtensions.cpp
@@ -134,7 +134,7 @@ static jvmtiError JNICALL GetCarrierThread(const jvmtiEnv* env, ...) {
     return JVMTI_ERROR_NULL_POINTER;
   }
 
-  BSD_AARCH64_ONLY(ThreadWXEnable __wx(WXWrite, current_thread));
+  MACOS_AARCH64_ONLY(ThreadWXEnable __wx(WXWrite, current_thread));
   ThreadInVMfromNative tiv(current_thread);
   MountUnmountDisabler disabler;
 

--- a/src/hotspot/share/prims/unsafe.cpp
+++ b/src/hotspot/share/prims/unsafe.cpp
@@ -369,7 +369,7 @@ UNSAFE_ENTRY(void, Unsafe_SetMemory0(JNIEnv *env, jobject unsafe, jobject obj, j
   {
     GuardUnsafeAccess guard(thread);
     if (StubRoutines::unsafe_setmemory() != nullptr) {
-      BSD_AARCH64_ONLY(ThreadWXEnable wx(WXExec, thread));
+      MACOS_AARCH64_ONLY(ThreadWXEnable wx(WXExec, thread));
       StubRoutines::UnsafeSetMemory_stub()(p, sz, value);
     } else {
       Copy::fill_to_memory_atomic(p, sz, value);
@@ -388,7 +388,7 @@ UNSAFE_ENTRY(void, Unsafe_CopyMemory0(JNIEnv *env, jobject unsafe, jobject srcOb
   {
     GuardUnsafeAccess guard(thread);
     if (StubRoutines::unsafe_arraycopy() != nullptr) {
-      BSD_AARCH64_ONLY(ThreadWXEnable wx(WXExec, thread));
+      MACOS_AARCH64_ONLY(ThreadWXEnable wx(WXExec, thread));
       StubRoutines::UnsafeArrayCopy_stub()(src, dst, sz);
     } else {
       Copy::conjoint_memory_atomic(src, dst, sz);
@@ -440,14 +440,14 @@ UNSAFE_LEAF (void, Unsafe_WriteBack0(JNIEnv *env, jobject unsafe, jlong line)) {
   }
 #endif
 
-  BSD_AARCH64_ONLY(ThreadWXEnable wx(WXExec, Thread::current()));
+  MACOS_AARCH64_ONLY(ThreadWXEnable wx(WXExec, Thread::current()));
   assert(StubRoutines::data_cache_writeback() != nullptr, "sanity");
   (StubRoutines::DataCacheWriteback_stub())(addr_from_java(line));
 } UNSAFE_END
 
 static void doWriteBackSync0(bool is_pre)
 {
-  BSD_AARCH64_ONLY(ThreadWXEnable wx(WXExec, Thread::current()));
+  MACOS_AARCH64_ONLY(ThreadWXEnable wx(WXExec, Thread::current()));
   assert(StubRoutines::data_cache_writeback_sync() != nullptr, "sanity");
   (StubRoutines::DataCacheWritebackSync_stub())(is_pre);
 }

--- a/src/hotspot/share/prims/upcallLinker.cpp
+++ b/src/hotspot/share/prims/upcallLinker.cpp
@@ -85,7 +85,7 @@ JavaThread* UpcallLinker::on_entry(UpcallStub::FrameData* context) {
 
   // The call to transition_from_native below contains a safepoint check
   // which needs the code cache to be writable.
-  BSD_AARCH64_ONLY(ThreadWXEnable wx(WXWrite, thread));
+  MACOS_AARCH64_ONLY(ThreadWXEnable wx(WXWrite, thread));
 
   // After this, we are officially in Java Code. This needs to be done before we change any of the thread local
   // info, since we cannot find oops before the new information is set up completely.

--- a/src/hotspot/share/prims/whitebox.inline.hpp
+++ b/src/hotspot/share/prims/whitebox.inline.hpp
@@ -33,7 +33,7 @@
 
 #define WB_ENTRY(result_type, header) JNI_ENTRY(result_type, header) \
   ClearPendingJniExcCheck _clearCheck(env); \
-  BSD_AARCH64_ONLY(ThreadWXEnable _wx(WXWrite, thread));
+  MACOS_AARCH64_ONLY(ThreadWXEnable _wx(WXWrite, thread));
 
 #define WB_END JNI_END
 

--- a/src/hotspot/share/runtime/continuationFreezeThaw.cpp
+++ b/src/hotspot/share/runtime/continuationFreezeThaw.cpp
@@ -249,7 +249,7 @@ static JRT_LEAF(intptr_t*, thaw(JavaThread* thread, int kind))
   DEBUG_ONLY(PauseNoSafepointVerifier pnsv(&__nsv);)
 
   // we might modify the code cache via BarrierSetNMethod::nmethod_entry_barrier
-  BSD_AARCH64_ONLY(ThreadWXEnable __wx(WXWrite, thread));
+  MACOS_AARCH64_ONLY(ThreadWXEnable __wx(WXWrite, thread));
   return ConfigT::thaw(thread, (Continuation::thaw_kind)kind);
 JRT_END
 

--- a/src/hotspot/share/runtime/deoptimization.cpp
+++ b/src/hotspot/share/runtime/deoptimization.cpp
@@ -2241,7 +2241,7 @@ Deoptimization::update_method_data_from_interpreter(MethodData* trap_mdo, int tr
 
 Deoptimization::UnrollBlock* Deoptimization::uncommon_trap(JavaThread* current, jint trap_request, jint exec_mode) {
   // Enable WXWrite: current function is called from methods compiled by C2 directly
-  BSD_AARCH64_ONLY(ThreadWXEnable wx(WXWrite, current));
+  MACOS_AARCH64_ONLY(ThreadWXEnable wx(WXWrite, current));
 
   // Still in Java no safepoints
   {

--- a/src/hotspot/share/runtime/interfaceSupport.inline.hpp
+++ b/src/hotspot/share/runtime/interfaceSupport.inline.hpp
@@ -283,7 +283,7 @@ class VMNativeEntryWrapper {
   result_type header {                                               \
     assert(current == JavaThread::current(), "Must be");             \
     ThreadInVMfromJava __tiv(current);                               \
-    BSD_AARCH64_ONLY(                                              \
+    MACOS_AARCH64_ONLY(                                              \
       static WXMode wx_mode = DefaultWXWriteMode;                    \
       ThreadWXEnable __wx(&wx_mode, current);                        \
     )                                                                \
@@ -314,7 +314,7 @@ class VMNativeEntryWrapper {
   result_type header {                                               \
     assert(current == JavaThread::current(), "Must be");             \
     ThreadInVMfromJava __tiv(current, false /* check asyncs */);     \
-    BSD_AARCH64_ONLY(                                              \
+    MACOS_AARCH64_ONLY(                                              \
       static WXMode wx_mode = DefaultWXWriteMode;                    \
       ThreadWXEnable __wx(&wx_mode, current);                        \
     )                                                                \
@@ -326,7 +326,7 @@ class VMNativeEntryWrapper {
 #define JRT_BLOCK_ENTRY(result_type, header)                         \
   result_type header {                                               \
     assert(current == JavaThread::current(), "Must be");             \
-    BSD_AARCH64_ONLY(                                              \
+    MACOS_AARCH64_ONLY(                                              \
       static WXMode wx_mode = DefaultWXWriteMode;                    \
       ThreadWXEnable __wx(&wx_mode, current);                        \
     )                                                                \
@@ -367,7 +367,7 @@ extern "C" {                                                         \
     JavaThread* thread=JavaThread::thread_from_jni_environment(env); \
     assert(thread == Thread::current(), "JNIEnv is only valid in same thread"); \
     ThreadInVMfromNative __tiv(thread);                              \
-    BSD_AARCH64_ONLY(                                              \
+    MACOS_AARCH64_ONLY(                                              \
       static WXMode wx_mode = DefaultWXWriteMode;                    \
       ThreadWXEnable __wx(&wx_mode, thread);                         \
     )                                                                \
@@ -395,7 +395,7 @@ extern "C" {                                                         \
   result_type JNICALL header {                                       \
     JavaThread* thread=JavaThread::thread_from_jni_environment(env); \
     ThreadInVMfromNative __tiv(thread);                              \
-    BSD_AARCH64_ONLY(                                              \
+    MACOS_AARCH64_ONLY(                                              \
       static WXMode wx_mode = DefaultWXWriteMode;                    \
       ThreadWXEnable __wx(&wx_mode, thread);                         \
     )                                                                \
@@ -408,7 +408,7 @@ extern "C" {                                                         \
   result_type JNICALL header {                                       \
     JavaThread* thread = JavaThread::current();                      \
     ThreadInVMfromNative __tiv(thread);                              \
-    BSD_AARCH64_ONLY(                                              \
+    MACOS_AARCH64_ONLY(                                              \
       static WXMode wx_mode = DefaultWXWriteMode;                    \
       ThreadWXEnable __wx(&wx_mode, thread);                         \
     )                                                                \

--- a/src/hotspot/share/runtime/javaThread.cpp
+++ b/src/hotspot/share/runtime/javaThread.cpp
@@ -1124,7 +1124,7 @@ void JavaThread::check_special_condition_for_native_trans(JavaThread *thread) {
   thread->set_thread_state(_thread_in_vm);
 
   // Enable WXWrite: called directly from interpreter native wrapper.
-  BSD_AARCH64_ONLY(ThreadWXEnable wx(WXWrite, thread));
+  MACOS_AARCH64_ONLY(ThreadWXEnable wx(WXWrite, thread));
 
   SafepointMechanism::process_if_requested_with_exit_check(thread, true /* check asyncs */);
 
@@ -1306,7 +1306,7 @@ void JavaThread::verify_states_for_handshake() {
 
 void JavaThread::nmethods_do(NMethodClosure* cf) {
   DEBUG_ONLY(verify_frame_info();)
-  BSD_AARCH64_ONLY(ThreadWXEnable wx(WXWrite, Thread::current());)
+  MACOS_AARCH64_ONLY(ThreadWXEnable wx(WXWrite, Thread::current());)
 
   if (has_last_Java_frame()) {
     // Traverse the execution stack

--- a/src/hotspot/share/runtime/safepoint.cpp
+++ b/src/hotspot/share/runtime/safepoint.cpp
@@ -618,7 +618,7 @@ void SafepointSynchronize::handle_polling_page_exception(JavaThread *thread) {
   thread->set_thread_state(_thread_in_vm);
 
   // Enable WXWrite: the function is called implicitly from java code.
-  BSD_AARCH64_ONLY(ThreadWXEnable wx(WXWrite, thread));
+  MACOS_AARCH64_ONLY(ThreadWXEnable wx(WXWrite, thread));
 
   if (log_is_enabled(Info, safepoint, stats)) {
     AtomicAccess::inc(&_nof_threads_hit_polling_page);

--- a/src/hotspot/share/runtime/sharedRuntime.cpp
+++ b/src/hotspot/share/runtime/sharedRuntime.cpp
@@ -1799,7 +1799,7 @@ JRT_LEAF(void, SharedRuntime::fixup_callers_callsite(Method* method, address cal
 
   // write lock needed because we might patch call site by set_to_clean()
   // and is_unloading() can modify nmethod's state
-  BSD_AARCH64_ONLY(ThreadWXEnable __wx(WXWrite, JavaThread::current()));
+  MACOS_AARCH64_ONLY(ThreadWXEnable __wx(WXWrite, JavaThread::current()));
 
   CodeBlob* cb = CodeCache::find_blob(caller_pc);
   if (cb == nullptr || !cb->is_nmethod() || !callee->is_in_use() || callee->is_unloading()) {

--- a/src/hotspot/share/runtime/stubRoutines.hpp
+++ b/src/hotspot/share/runtime/stubRoutines.hpp
@@ -337,13 +337,13 @@ public:
 
   static jshort f2hf(jfloat x) {
     assert(_f2hf != nullptr, "stub is not implemented on this platform");
-    BSD_AARCH64_ONLY(ThreadWXEnable wx(WXExec, Thread::current());) // About to call into code cache
+    MACOS_AARCH64_ONLY(ThreadWXEnable wx(WXExec, Thread::current());) // About to call into code cache
     typedef jshort (*f2hf_stub_t)(jfloat x);
     return ((f2hf_stub_t)_f2hf)(x);
   }
   static jfloat hf2f(jshort x) {
     assert(_hf2f != nullptr, "stub is not implemented on this platform");
-    BSD_AARCH64_ONLY(ThreadWXEnable wx(WXExec, Thread::current());) // About to call into code cache
+    MACOS_AARCH64_ONLY(ThreadWXEnable wx(WXExec, Thread::current());) // About to call into code cache
     typedef jfloat (*hf2f_stub_t)(jshort x);
     return ((hf2f_stub_t)_hf2f)(x);
   }

--- a/src/hotspot/share/runtime/threadWXSetters.inline.hpp
+++ b/src/hotspot/share/runtime/threadWXSetters.inline.hpp
@@ -83,68 +83,6 @@ public:
 
   static bool test(address p);
 };
-#elif defined(_BSDONLY_SOURCE) && defined(AARCH64)
-
-//
-// Per https://cr.openjdk.org/~jrose/jvm/hotspot-cmc.html, HotSpot
-// will cross-modify code.
-//
-// To workaround the potential subtle race issues outlined in the
-// paper linked to above, HotSpot calls pthread_jit_write_protect_np()
-// on Darwin/aarch64.  On other OSes, different workarounds are applied,
-// but some of these appear Cortex specific and are not sufficient on
-// NetBSD and FreeBSD when running on Apple Silicon (see
-// https://mail-index.netbsd.org/tech-pkg/2025/07/12/msg031385.html and
-// https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=265284).
-//
-// Using pthread_jit_write_protect_np() will temporarily write-protect
-// every executable page in the process space for the calling thread,
-// so that the thread can execute code in pages that are otherwise
-// writable.  The important part, from our perspective, is that the
-// function happens to issue data and instruction memory barriers
-// (i.e. DSB and ISB).  These are enough to address the issues on
-// NetBSD and FreeBSD.
-//
-// To that end, issue these memory barriers every time Darwin would
-// call pthread_jit_write_protect_np().  This is implemented below and
-// by the calls to BSD_AARCH64_ONLY(ThreadWXEnable wx(WXWrite, <thread>)
-// throughout the code (formerly MACOS_AARCH64_ONLY).
-//
-// Notes:
-// 1. This has a negative performance impact on Cortex chips, but we'll
-//    accept that in favour of correctness overall
-// 2. OpenBSD doesn't seem to be impacted by this, although it is not
-//    clear why that is
-//
-
-class ThreadWXEnable  {
-  WXMode _new_mode;
-public:
-  ThreadWXEnable(WXMode * new_mode, Thread*) :
-    _new_mode(*new_mode)
-  {
-    if (_new_mode == WXExec) {
-      // We are going to execute some code that has been potentially
-      // modified.
-      __asm__ __volatile__ ("dsb\tsy\n"
-                            "isb\tsy" : : : "memory");
-    }
-  }
-
-  ThreadWXEnable(WXMode new_mode, Thread * t)
-  {
-    ThreadWXEnable(&new_mode, t);
-  }
-
-  ~ThreadWXEnable() {
-    if (_new_mode == WXWrite) {
-      // We may have modified some code that is going to be executed
-      // outside of this block.
-      __asm__ __volatile__ ("dsb\tsy\n"
-                            "isb\tsy" : : : "memory");
-    }
-  }
-};
 #endif // MACOS_AARCH64
 
 #endif // SHARE_RUNTIME_THREADWXSETTERS_INLINE_HPP

--- a/src/hotspot/share/utilities/macros.hpp
+++ b/src/hotspot/share/utilities/macros.hpp
@@ -523,8 +523,6 @@
 #define MACOS_AARCH64 1
 #endif
 
-#define BSD_AARCH64_ONLY(x) BSD_ONLY(AARCH64_ONLY(x))
-
 #if defined(RISCV32) || defined(RISCV64)
 #define RISCV
 #define RISCV_ONLY(code) code


### PR DESCRIPTION
It appears the research that went into the patch that introduces this in the BSD port was lacking. Removing it, so we can start afresh if there's indeed any issues to solve.

Thanks to Kurt Miller for clearing things up a bit.

This work is sponsored by The FreeBSD Foundation




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).
