### PR TITLE
Use FreeBSD 14.4 in GHA workflows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -420,7 +420,7 @@ jobs:
       platform: freebsd-x64
       runs-on: ubuntu-24.04
       vm-arch: 'x86_64'
-      vm-release: "14.3"
+      vm-release: "14.4"
       configure-arguments: ${{ github.event.inputs.configure-arguments }}
       make-arguments: ${{ github.event.inputs.make-arguments }}
       dry-run: ${{ needs.prepare.outputs.dry-run == 'true' }}
@@ -524,7 +524,7 @@ jobs:
     with:
       platform: freebsd-x64
       runs-on: ubuntu-24.04
-      vm-release: 14.3
+      vm-release: 14.4
       vm-arch: x86_64
       dry-run: ${{ needs.prepare.outputs.dry-run == 'true' }}
       debug-suffix: -debug


### PR DESCRIPTION
This fixes the build failures for the FreeBSD GHA workflows.

This work is sponsored by The FreeBSD Foundation




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).
