### PR TITLE
Refactor BSD os::rss and os::Bsd::get_process_uid

### DIFF
--- a/src/hotspot/os/bsd/os_bsd.cpp
+++ b/src/hotspot/os/bsd/os_bsd.cpp
@@ -66,6 +66,7 @@
 #include "utilities/defaultStream.hpp"
 #include "utilities/events.hpp"
 #include "utilities/growableArray.hpp"
+#include "utilities/macros.hpp"
 #include "utilities/vmError.hpp"
 #if INCLUDE_JFR
 #include "jfr/jfrEvents.hpp"
@@ -354,6 +355,17 @@ physical_memory_size_type os::Machine::physical_memory() {
   return Bsd::physical_memory();
 }
 
+static int bsd_get_procinfo(pid_t pid, struct KINFO_PROC_T *kp, size_t *bufSize) {
+  int mib[] = {CTL_KERN, KERN_PROC_MIB, KERN_PROC_PID, pid,
+# if !defined(__FreeBSD__) && !defined(__APPLE__)
+               static_cast<int>(*bufSize), 1
+# endif
+  };
+  const u_int namelen = sizeof(mib)/sizeof(mib[0]);
+
+  return sysctl(mib, namelen, kp, bufSize, nullptr, 0);
+}
+
 size_t os::rss() {
   size_t rss = 0;
 #ifdef __APPLE__
@@ -366,19 +378,11 @@ size_t os::rss() {
     rss = info.resident_size;
   }
 #else
-  pid_t pid = getpid();
   struct KINFO_PROC_T kp;
-  size_t bufSize = sizeof kp;
-#ifndef __FreeBSD__
-  u_int namelen = 6;
-  int mib[6] = {CTL_KERN, KERN_PROC_MIB, KERN_PROC_PID, pid,
-                static_cast<int>(bufSize), 1};
-#else
-  u_int namelen = 4;
-  int mib[4] = {CTL_KERN, KERN_PROC, KERN_PROC_PID, pid};
-#endif
-  if (sysctl(mib, namelen, &kp, &bufSize, nullptr, 0) != -1) {
-    return kp.KI_RSS * getpagesize();
+  size_t bufSize = sizeof(kp);
+
+  if (bsd_get_procinfo(getpid(), &kp, &bufSize) != -1) {
+    rss = kp.KI_RSS * getpagesize();
   }
 #endif // __APPLE__
 
@@ -1034,17 +1038,9 @@ pid_t os::Bsd::gettid() {
 
 // Returns the uid of a process or -1 on error.
 uid_t os::Bsd::get_process_uid(pid_t pid) {
-  struct KINFO_PROC_T kp;
+  struct kinfo_proc kp;
   size_t size = sizeof kp;
-#if defined(__FreeBSD__) || defined(__APPLE__)
-  u_int namelen = 4;
-  int mib_kern[4] = {CTL_KERN, KERN_PROC_MIB, KERN_PROC_PID, pid};
-#else
-  u_int namelen = 6;
-  int mib_kern[6] = {CTL_KERN, KERN_PROC_MIB, KERN_PROC_PID, pid,
-                static_cast<int>(size), 1};
-#endif
-  if (sysctl(mib_kern, namelen, &kp, &size, nullptr, 0) == 0) {
+  if (bsd_get_procinfo(pid, &kp, &size) == 0) {
     if (size > 0 && kp.KI_PID == pid) {
       return kp.KI_UID;
     }

--- a/src/hotspot/os/bsd/os_bsd.cpp
+++ b/src/hotspot/os/bsd/os_bsd.cpp
@@ -66,7 +66,6 @@
 #include "utilities/defaultStream.hpp"
 #include "utilities/events.hpp"
 #include "utilities/growableArray.hpp"
-#include "utilities/macros.hpp"
 #include "utilities/vmError.hpp"
 #if INCLUDE_JFR
 #include "jfr/jfrEvents.hpp"


### PR DESCRIPTION
Moved the common sysctl call to a helper function `bsd_get_procinfo`, and simplified it a bit.

This work is sponsored by The FreeBSD Foundation




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).
