### PR TITLE
8388115: Provide os::vm_min_address() for BSD

### DIFF
--- a/src/hotspot/os/bsd/os_bsd.cpp
+++ b/src/hotspot/os/bsd/os_bsd.cpp
@@ -107,16 +107,19 @@
   #include <pthread_np.h>
   #include <sys/link_elf.h>
   #include <vm/vm_param.h>
+  #include <machine/vmparam.h>
 #endif
 
 #ifdef __NetBSD__
-#include <link_elf.h>
-#include <lwp.h>
+  #include <link_elf.h>
+  #include <lwp.h>
+  #include <machine/vmparam.h>
 #endif
 
 #ifdef __OpenBSD__
   #include <pthread_np.h>
   #include <link_elf.h>
+  #include <machine/vmparam.h>
 #endif
 
 #ifdef __APPLE__
@@ -2186,7 +2189,8 @@ size_t os::vm_min_address() {
   return 4 * G;
 #else
   assert(is_aligned(_vm_min_address_default, os::vm_allocation_granularity()), "Sanity");
-  return _vm_min_address_default;
+  assert(is_aligned(VM_MIN_ADDRESS, os::vm_allocation_granularity()), "Sanity");
+  return MAX2(_vm_min_address_default, (size_t)VM_MIN_ADDRESS);
 #endif
 }
 


### PR DESCRIPTION
https://bugs.openjdk.org/browse/JDK-8388115 requests implementation of `os::vm_min_address()` and `os::vm_max_address()` for BSD. `os::vm_max_address()` has not yet been merged into master but I have discussed the current BSD implementation of `os::vm_min_address()` with @tstuefe and came up with this change.

This PR is for correctness and does not change the return value of `os::vm_min_address()` on BSD because `VM_MIN_ADDRESS` is less then `_vm_min_address_default` on FreeBSD, OpenBSD and NetBSD. However, if some future architecture or future change to `VM_MIN_ADDRESS` makes it greater then `_vm_min_address_default`, the jdk is prepared for that change.

Of note is that `_vm_min_address_default` not only is the default value but also serves as a minimum value the JDK supports.  When https://github.com/openjdk/jdk/pull/31864 lands in master, I will follow up with BSD implementation of `os::vm_max_address()` that uses `VM_MAXUSER_ADDRESS`.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).
