### PR TITLE
Use 12g for BSD VM memory in GHA

### DIFF
--- a/.github/workflows/build-freebsd.yml
+++ b/.github/workflows/build-freebsd.yml
@@ -111,7 +111,7 @@ jobs:
         with:
           release: ${{ inputs.vm-release }}
           arch: ${{ inputs.vm-arch }}
-          mem: 11264
+          mem: 12288
           cpu: 4
           envs: 'MYTOKEN'
           usesh: true

--- a/.github/workflows/build-openbsd.yml
+++ b/.github/workflows/build-openbsd.yml
@@ -120,7 +120,7 @@ jobs:
         with:
           release: ${{ inputs.vm-release }}
           arch: ${{ inputs.vm-arch }}
-          mem: 11264
+          mem: 12288
           cpu: 4
           envs: 'MYTOKEN'
           usesh: true

--- a/.github/workflows/test-freebsd.yml
+++ b/.github/workflows/test-freebsd.yml
@@ -182,7 +182,7 @@ jobs:
         with:
           release: ${{ inputs.vm-release }}
           arch: ${{ inputs.vm-arch }}
-          mem: 11264
+          mem: 12288
           cpu: 4
           envs: 'MYTOKEN'
           usesh: true

--- a/.github/workflows/test-openbsd.yml
+++ b/.github/workflows/test-openbsd.yml
@@ -191,7 +191,7 @@ jobs:
         with:
           release: ${{ inputs.vm-release }}
           arch: ${{ inputs.vm-arch }}
-          mem: 11264
+          mem: 12288
           cpu: 4
           envs: 'MYTOKEN'
           usesh: true


### PR DESCRIPTION
I noticed that some of the intermittent failures on OpenBSD testing in GHA appeared to be with tests that use a large amount of memory, such as `java/math/BigInteger/largeMemory/SymmetricRangeTests.java`. With OpenBSD's heavy use of address space layout randomization, I surmised that perhaps a lack of physical memory in the guest OS may be the cause. 

Increasing the guest OS memory from 11g to 12g does appear to eliminate the intermittent failure I occasionally see on OpenBSD in GHA with `SymmetricRangeTests.java`. I ran 10 GHA with this change and the only remaining intermittent failure I see now is under `jdk/jshell/* `which I believe to be unrelated at this time.

---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).