### PR TITLE
Add variant lib dir to lib runpaths on FreeBSD

### DIFF
--- a/make/common/JdkNativeCompilation.gmk
+++ b/make/common/JdkNativeCompilation.gmk
@@ -59,6 +59,10 @@ else ifeq ($(call isCompiler, clang), true)
     ifeq ($(call isTargetOs, arm), true)
       SetSharedLibraryOrigin = \
           -Wl,-rpath,\$(DOLLAR)ORIGIN$1
+    else ifeq ($(call isTargetOsEnv, bsd.freebsd), true)
+      SetSharedLibraryOrigin = \
+          -Wl,-z,origin -Wl,-rpath,\$(DOLLAR)ORIGIN$1 \
+          -Wl,-rpath,\$(DOLLAR)ORIGIN$1/$(JVM_VARIANT_MAIN)
     else
       SetSharedLibraryOrigin = \
           -Wl,-z,origin -Wl,-rpath,\$(DOLLAR)ORIGIN$1


### PR DESCRIPTION
The Elf DT_RUNPATH tag added to libraries only contained $ORIGIN, but since libjvm was located in the $ORIGIN/$JVM_VARIANT_MAIN directory, it was not found by the elf loader on FreeBSD.

It would instead pick up the libjvm from OpenJDK 11, if present, and fail to load if not.

The actual libjvm is loaded on demand, though, and would pick up the right JVM for the java version running.

This work is sponsored by The FreeBSD Foundation




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).
