### PR TITLE
Restore hidden symbols by default for BSD

### DIFF
--- a/make/autoconf/flags-cflags.m4
+++ b/make/autoconf/flags-cflags.m4
@@ -586,7 +586,7 @@ AC_DEFUN([FLAGS_SETUP_CFLAGS_HELPER],
       TOOLCHAIN_CFLAGS_JDK="-ffunction-sections -fsigned-char"
     fi
 
-    if test "x$OPENJDK_TARGET_OS" != xbsd; then
+    if test "x$OPENJDK_TARGET_OS_ENV" != xbsd.freebsd; then
       TOOLCHAIN_CFLAGS_JVM="$TOOLCHAIN_CFLAGS_JVM -fvisibility=hidden"
     fi
 

--- a/make/autoconf/flags-cflags.m4
+++ b/make/autoconf/flags-cflags.m4
@@ -538,11 +538,11 @@ AC_DEFUN([FLAGS_SETUP_CFLAGS_HELPER],
   if test "x$TOOLCHAIN_TYPE" = xgcc || test "x$TOOLCHAIN_TYPE" = xclang; then
     # COMMON to gcc and clang
     TOOLCHAIN_CFLAGS_JVM="-pipe -fno-rtti -fno-exceptions \
-        -fno-strict-aliasing -fno-omit-frame-pointer"
+        -fvisibility=hidden -fno-strict-aliasing -fno-omit-frame-pointer"
   fi
 
   if test "x$TOOLCHAIN_TYPE" = xgcc; then
-    TOOLCHAIN_CFLAGS_JVM="$TOOLCHAIN_CFLAGS_JVM -fvisibility=hidden -fstack-protector"
+    TOOLCHAIN_CFLAGS_JVM="$TOOLCHAIN_CFLAGS_JVM -fstack-protector"
     TOOLCHAIN_CFLAGS_JDK="-fvisibility=hidden -pipe -fstack-protector"
     # reduce lib size on linux in link step, this needs also special compile flags
     if test "x$ENABLE_LINKTIME_GC" = xtrue; then
@@ -584,10 +584,6 @@ AC_DEFUN([FLAGS_SETUP_CFLAGS_HELPER],
     if test "x$OPENJDK_TARGET_OS" = xaix; then
       TOOLCHAIN_CFLAGS_JVM="$TOOLCHAIN_CFLAGS_JVM -ffunction-sections -ftls-model -fno-math-errno"
       TOOLCHAIN_CFLAGS_JDK="-ffunction-sections -fsigned-char"
-    fi
-
-    if test "x$OPENJDK_TARGET_OS_ENV" != xbsd.freebsd; then
-      TOOLCHAIN_CFLAGS_JVM="$TOOLCHAIN_CFLAGS_JVM -fvisibility=hidden"
     fi
 
     TOOLCHAIN_CFLAGS_JDK="$TOOLCHAIN_CFLAGS_JDK -fvisibility=hidden -fstack-protector"

--- a/src/hotspot/os/bsd/os_bsd.cpp
+++ b/src/hotspot/os/bsd/os_bsd.cpp
@@ -1137,8 +1137,24 @@ static int local_dladdr(const void* addr, Dl_info* info) {
     // value should not be allowed to work to avoid confusion.
     return 0;
   }
-#endif
   return dladdr(addr, info);
+#else
+  int ret = dladdr(addr, info);
+  if (ret == 0)
+    return ret;
+  // On BSD dladdr(3) returns the nearest run-time symbol with an
+  // address less than or equal to addr, whereas on linux it only
+  // returns a symbol if the addr >= the symbol address AND <
+  // the symbol address + symbol size. Since the jvm wants more
+  // accurate symbol resolution, only return symbols that are
+  // an exact match so that Decoder::decode can be called as a fallback.
+  if (info->dli_saddr != nullptr && info->dli_sname != nullptr &&
+      addr != info->dli_saddr) {
+    info->dli_saddr = nullptr;
+    info->dli_sname = nullptr;
+  }
+  return ret;
+#endif
 }
 
 // This must be hard coded because it's the system's temporary
@@ -2545,7 +2561,7 @@ void os::set_native_thread_name(const char *name) {
 bool os::find(address addr, outputStream* st) {
   Dl_info dlinfo;
   memset(&dlinfo, 0, sizeof(dlinfo));
-  if (dladdr(addr, &dlinfo) != 0) {
+  if (local_dladdr(addr, &dlinfo) != 0) {
     st->print(INTPTR_FORMAT ": ", (intptr_t)addr);
     if (dlinfo.dli_sname != nullptr && dlinfo.dli_saddr != nullptr) {
       st->print("%s+%#x", dlinfo.dli_sname,
@@ -2571,7 +2587,7 @@ bool os::find(address addr, outputStream* st) {
       if (!lowest)  lowest = (address) dlinfo.dli_fbase;
       if (begin < lowest)  begin = lowest;
       Dl_info dlinfo2;
-      if (dladdr(end, &dlinfo2) != 0 && dlinfo2.dli_saddr != dlinfo.dli_saddr
+      if (local_dladdr(end, &dlinfo2) != 0 && dlinfo2.dli_saddr != dlinfo.dli_saddr
           && end > dlinfo2.dli_saddr && dlinfo2.dli_saddr > begin) {
         end = (address) dlinfo2.dli_saddr;
       }


### PR DESCRIPTION
As I was back-porting commits to fix test failures in hotspot tier1 common, I found that I needed to back-port the commits that removed `-fvisibility=hidden` for BSD. Since this is a departure from what the other operating systems did, I decided to take a deep dive and find out why this was needed and to see if we could keep `-fvisibility=hidden` for BSD. The impact of removing this is that all libjvm.so symbols become globally visible and exported. It also exposes internal APIs, makes the dynsym table quite large and prevents certain optimizations.

After reverting the commits that removed `-fvisibility=hidden` for BSD the following test failures came back:

hotspot tier1 common:
- gtest/GTestWrapper
- gtest/NMTGtests#nmt-detail
- gtest/NMTGtests#nmt-off
- gtest/NMTGtests#nmt-summary

hotspot tier1 runtime:
- runtime/ErrorHandling/SecondaryErrorTest#id1
- runtime/ErrorHandling/TestSigInfoInHsErrFile
- runtime/NMT/CheckForProperDetailStackTrace

All of these failures track back to `os::dll_address_to_function_name()` and it needing to be able to return function names for local/hidden symbols. The BSD implementation of this function matches Linux where it calls `dladdr(3)` first and if the symbol address and name is returned it uses that, otherwise it calls `Decoder::decode()` to read the Elf data to find the match.

The issue here is that on BSD `dladdr(3)` implementation differs from Linux in that Linux will only return a symbol match when the provided `addr` matches a globally visible symbol address or falls within its `address + the symbol size`. On BSD `dladdr(3)` returns the globally visible symbol that is less than or equal to the provided `addr`. So on BSD we almost always return a symbol and prevent the fall back to `Decoder::decode()` and all local symbols are miss-reported as the closest global symbol with a large offset.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).
